### PR TITLE
Handle rendering SVG image and failures

### DIFF
--- a/demo/src/rise-image.html
+++ b/demo/src/rise-image.html
@@ -37,12 +37,23 @@
     file="risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f/stu-testing/images/rise-image-demo/Costa Rican Frog.jpg">
   </rise-image>
 
+  <rise-image
+    id="rise-image-02"
+    label="SVG Image"
+    file="risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f/rise-image-demo/PokemonGO-Team-Logos-Instinct.svg">
+  </rise-image>
+
   <script>
     function configureComponents() {
-      const image01 = document.querySelector('#rise-image-01');
+      const image01 = document.querySelector('#rise-image-01'),
+        image02 = document.querySelector('#rise-image-02');
 
       image01.addEventListener( "image-error", ( evt ) => {
-        console.log( "image error", evt.detail );
+        console.log( "image 1 error", evt.detail );
+      } );
+
+      image02.addEventListener( "image-error", ( evt ) => {
+        console.log( "image 2 error", evt.detail );
       } );
 
       // Uncomment the following line if the image component is marked as non-editable

--- a/test/integration/rise-image-logging.html
+++ b/test/integration/rise-image-logging.html
@@ -182,6 +182,75 @@
         }, watchTimeoutDuration );
     } );
 
+    test( "should log 'svg-usage' event with svg details", done => {
+        const filePath = "risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f/rise-image-demo/PokemonGO-Team-Logos-Instinct.svg";
+
+        RisePlayerConfiguration.LocalStorage = {
+            watchSingleFile: ( file, handler ) => {
+                setTimeout(
+                  () => handler({ status: "CURRENT", fileUrl: `https://storage.googleapis.com/${filePath}` }), watchTimeoutDuration
+                );
+            }
+        };
+
+          element.file = "risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f/rise-image-demo/PokemonGO-Team-Logos-Instinct.svg";
+          element.dispatchEvent( new CustomEvent( "start" ));
+
+          setTimeout(() => {
+              assert.deepEqual( RisePlayerConfiguration.Logger.info.args[ 2 ][ 0 ], componentData );
+              assert.equal( RisePlayerConfiguration.Logger.info.args[ 2 ][ 1 ], "svg-usage");
+              assert.property( RisePlayerConfiguration.Logger.info.args[ 2 ][ 2 ].svg_details, "blob_size");
+              assert.property( RisePlayerConfiguration.Logger.info.args[ 2 ][ 2 ].svg_details, "data_url_length");
+              assert.deepEqual( RisePlayerConfiguration.Logger.info.args[ 2 ][ 3 ], {
+                  storage: {
+                      configuration: "storage file",
+                      file_form: "svg",
+                      file_path: filePath,
+                      local_url: `https://storage.googleapis.com/${filePath}`
+                  }
+              } );
+
+              done();
+          }, 3000 );
+    });
+
+    test("should log an 'image-error' when rendering an SVG file files", done => {
+        sinon.stub(element, "_getDataUrlFromSVGLocalUrl").callsFake(() => {
+            return Promise.reject("Request failed: 404: Not found");
+        });
+
+        const filePath = "risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f/rise-image-demo/PokemonGO-Team-Logos-Instinct.svg";
+
+        RisePlayerConfiguration.LocalStorage = {
+            watchSingleFile: ( file, handler ) => {
+                setTimeout(
+                  () => handler({ status: "CURRENT", fileUrl: `https://storage.googleapis.com/${filePath}` }), watchTimeoutDuration
+                );
+            }
+        };
+
+        element.file = "risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f/rise-image-demo/PokemonGO-Team-Logos-Instinct.svg";
+        element.dispatchEvent( new CustomEvent( "start" ));
+
+        setTimeout(() => {
+            assert.deepEqual( RisePlayerConfiguration.Logger.error.args[ 0 ][ 0 ], componentData );
+            assert.equal( RisePlayerConfiguration.Logger.error.args[ 0 ][ 1 ], "image-error");
+            assert.equal( RisePlayerConfiguration.Logger.error.args[ 0 ][ 2 ], "Request failed: 404: Not found");
+            assert.deepEqual( RisePlayerConfiguration.Logger.error.args[ 0 ][ 3 ], {
+                storage: {
+                    configuration: "storage file",
+                    file_form: "svg",
+                    file_path: filePath,
+                    local_url: `https://storage.googleapis.com/${filePath}`
+                }
+            } );
+
+            element._getDataUrlFromSVGLocalUrl.restore();
+            done();
+        }, watchTimeoutDuration );
+
+    })
+
   });
 </script>
 </body>

--- a/test/unit/rise-image.html
+++ b/test/unit/rise-image.html
@@ -273,6 +273,61 @@
 
       } );
 
+      suite( "_getDataUrlFromSVGLocalUrl", () => {
+
+        let element,
+          xhr,
+          requests;
+
+        setup( () => {
+          RisePlayerConfiguration.Logger = {
+            info: () => {}
+          };
+
+          element = fixture('test-block');
+
+          xhr = sinon.useFakeXMLHttpRequest();
+          requests = [];
+
+          xhr.onCreate = ( request ) => {
+            requests.push( request );
+          };
+        });
+
+        teardown( () => {
+          RisePlayerConfiguration.Logger = {};
+          xhr.restore();
+        });
+
+        test( "should get a data url response", function() {
+          const svg = `...`;
+          const blob = new Blob([svg], {type: 'image/svg+xml'});
+
+          let promise = element._getDataUrlFromSVGLocalUrl( "" )
+            .then( function( dataUrl ) {
+              assert( dataUrl );
+              assert.include( dataUrl, "data:image/svg+xml;base64");
+            });
+
+          requests[ 0 ].respond( 200, { "Content-Type": "blob" }, `${blob}` );
+
+          return promise;
+        });
+
+        test( "should return an error if xhr request fails", function() {
+          let promise = element._getDataUrlFromSVGLocalUrl( "" )
+            .catch( error => {
+              assert( error );
+              assert.include( error, "404" );
+            } );
+
+          requests[ 0 ].respond( 404, {}, "" );
+
+          return promise;
+        });
+
+      });
+
     </script>
   </body>
 </html>


### PR DESCRIPTION
- Converts SVG to data URL as per design and applies data url as _src_ of `<iron-image>`
- Logs `info` event containing SVG details (as we do for Image widget)
- Logs error and sends "image-error" event when SVG conversion fails (XHR request fail or FileReader fail)
- Updated demo to include an instance for rendering an SVG. 

**Note** The SVG will not display while the component currently does not apply a _width_ or _height_ for the `<iron-image>` instance. In inspecting and forcing a _width_, the SVG does appear as the internal `<img>` needs a width/height applied when having a dataurl applied as the source. The following screenshot proves the SVG gets rendered correctly (I added the width manually in dev tools).

![image](https://user-images.githubusercontent.com/7407007/57556012-cc5a8c00-7343-11e9-943b-cda4a4003e22.png)
