### PR TITLE
Support fixed and responsive sizing

### DIFF
--- a/demo/src/rise-image.html
+++ b/demo/src/rise-image.html
@@ -29,19 +29,42 @@
         }
       }
     </script>
+    <style>
+      #image01Wrapper {
+        width: 350px;
+        height: 350px;
+        position: relative;
+        background-color: beige;
+      }
+
+      #image02Wrapper {
+        width: 100%;
+        height: 350px;
+        position: relative;
+        background-color: darkgrey;
+      }
+    </style>
   </head>
   <body>
-  <rise-image
-    id="rise-image-01"
-    label="My Image"
-    file="risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f/stu-testing/images/rise-image-demo/Costa Rican Frog.jpg">
-  </rise-image>
+  <div id="image01Wrapper">
+    <rise-image
+      id="rise-image-01"
+      label="My Image"
+      responsive
+      file="risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f/rise-image-demo/Costa Rican Frog.jpg">
+    </rise-image>
+  </div>
 
-  <rise-image
-    id="rise-image-02"
-    label="SVG Image"
-    file="risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f/rise-image-demo/PokemonGO-Team-Logos-Instinct.svg">
-  </rise-image>
+
+  <div id="image02Wrapper">
+    <rise-image
+      id="rise-image-02"
+      label="SVG Image"
+      width="200"
+      height="200"
+      file="risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f/rise-image-demo/PokemonGO-Team-Logos-Instinct.svg">
+    </rise-image>
+  </div>
 
   <script>
     function configureComponents() {

--- a/src/rise-image.js
+++ b/src/rise-image.js
@@ -2,7 +2,6 @@
 
 import { PolymerElement } from "@polymer/polymer/polymer-element.js";
 import { html } from "@polymer/polymer/lib/utils/html-tag.js";
-import { updateStyles } from '@polymer/polymer/lib/mixins/element-mixin.js';
 import { version } from "./rise-image-version.js";
 import "@polymer/iron-image/iron-image.js";
 
@@ -27,11 +26,11 @@ class RiseImage extends PolymerElement {
         value: ""
       },
       width: {
-        type: Number,
+        type: String,
         value: null
       },
       height: {
-        type: Number,
+        type: String,
         value: null
       },
       sizing: {
@@ -219,8 +218,8 @@ class RiseImage extends PolymerElement {
     if ( this.responsive ) {
       this.$.image.updateStyles({ "--iron-image-width": "100%" });
     } else {
-      this.$.image.width = this.width;
-      this.$.image.height = this.height;
+      this.$.image.width = isNaN( this.width ) ? parseInt( this.width, 10 ) : this.width;
+      this.$.image.height = isNaN( this.height ) ? parseInt( this.height, 10 ) : this.height;
       this.$.image.sizing = this.sizing;
     }
 

--- a/src/rise-image.js
+++ b/src/rise-image.js
@@ -2,12 +2,20 @@
 
 import { PolymerElement } from "@polymer/polymer/polymer-element.js";
 import { html } from "@polymer/polymer/lib/utils/html-tag.js";
+import { updateStyles } from '@polymer/polymer/lib/mixins/element-mixin.js';
 import { version } from "./rise-image-version.js";
 import "@polymer/iron-image/iron-image.js";
 
 class RiseImage extends PolymerElement {
   static get template() {
     return html`
+      <style>
+        :host {
+          display: inline-block;
+          overflow: hidden;
+          position: relative;
+        }
+      </style>
       <iron-image id="image"></iron-image>
     `;
   }
@@ -17,6 +25,22 @@ class RiseImage extends PolymerElement {
       file: {
         type: String,
         value: ""
+      },
+      width: {
+        type: Number,
+        value: null
+      },
+      height: {
+        type: Number,
+        value: null
+      },
+      sizing: {
+        type: String,
+        value: "contain"
+      },
+      responsive: {
+        type: Boolean,
+        value: false
       }
     };
   }
@@ -192,6 +216,14 @@ class RiseImage extends PolymerElement {
   }
 
   _renderImage( url ) {
+    if ( this.responsive ) {
+      this.$.image.updateStyles({ "--iron-image-width": "100%" });
+    } else {
+      this.$.image.width = this.width;
+      this.$.image.height = this.height;
+      this.$.image.sizing = this.sizing;
+    }
+
     if ( this._getStorageFileFormat( this.file ) === "svg" ) {
       this._getDataUrlFromSVGLocalUrl( url )
         .then( dataUrl => {


### PR DESCRIPTION
- Surfacing `width`, `height`, and `sizing` property/attributes for use when requiring the image be set to a fixed size. Valid values for `sizing` attribute are _contain_ and _cover_ (defaults to _contain_) which correspond to the `background-size` CSS property values. If no value provided then image will take the size as defined by width/height. 
- `width` and `height` are of String type, so values can be for example "200" or "200px". Either way the _iron-image_ instance will be provided the Number value (as required)
- Surfacing a non-value `responsive` attribute to use when requiring the image to be responsive to parent container. By default the property is false, when used the width/height/sizing attributes will be ignored. 

**Note**
Experimented as well with validating an animation can be applied to the parent container of a `rise-image` instance. I did not apply this to the demo, let me know if you think it should be. 

HTML template code [here](https://www.screencast.com/t/3g0aLLTVag)

Capture [here](https://www.screencast.com/t/pWiWuiMvd7)
Note, the animation is choppy only cause of recording it via SnagIt. When not recording it looks smooth.