### PR TITLE
Support multiple files

### DIFF
--- a/demo/src/rise-image.html
+++ b/demo/src/rise-image.html
@@ -43,6 +43,13 @@
         position: relative;
         background-color: darkgrey;
       }
+
+      #image03Wrapper {
+        width: 450px;
+        height: 450px;
+        position: relative;
+        background-color: aqua;
+      }
     </style>
   </head>
   <body>
@@ -51,7 +58,7 @@
       id="rise-image-01"
       label="My Image"
       responsive
-      file="risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f/rise-image-demo/Costa Rican Frog.jpg">
+      files="risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f/rise-image-demo/Costa Rican Frog.jpg">
     </rise-image>
   </div>
 
@@ -62,20 +69,34 @@
       label="SVG Image"
       width="200"
       height="200"
-      file="risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f/rise-image-demo/PokemonGO-Team-Logos-Instinct.svg">
+      files="risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f/rise-image-demo/PokemonGO-Team-Logos-Instinct.svg">
+    </rise-image>
+  </div>
+
+  <div id="image03Wrapper">
+    <rise-image
+      id="rise-image-03"
+      label="My Image"
+      responsive
+      files="risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f/rise-image-demo/Pensive Parakeet.jpg|risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f/rise-image-demo/Boston City Flow.jpg">
     </rise-image>
   </div>
 
   <script>
     function configureComponents() {
       const image01 = document.querySelector('#rise-image-01'),
-        image02 = document.querySelector('#rise-image-02');
+        image02 = document.querySelector('#rise-image-02'),
+        image03 = document.querySelector('#rise-image-03');
 
       image01.addEventListener( "image-error", ( evt ) => {
         console.log( "image 1 error", evt.detail );
       } );
 
       image02.addEventListener( "image-error", ( evt ) => {
+        console.log( "image 2 error", evt.detail );
+      } );
+
+      image03.addEventListener( "image-error", ( evt ) => {
         console.log( "image 2 error", evt.detail );
       } );
 

--- a/src/rise-image.js
+++ b/src/rise-image.js
@@ -269,20 +269,20 @@ class RiseImage extends PolymerElement {
     }
   }
 
-  _clearImage() {
+  _clearDisplayedImage() {
     this.$.image.src = "";
   }
 
   _start() {
     if ( !this._isValidFiles( this.files )) {
-      this._clearImage();
+      this._clearDisplayedImage();
       return;
     }
 
     this._filesList = this._filterInvalidFileTypes( this.files.split( "|" ));
 
     if ( !this._filesList || !this._filesList.length || this._filesList.length === 0 ) {
-      this._clearImage();
+      this._clearDisplayedImage();
       return;
     }
 

--- a/src/rise-image.js
+++ b/src/rise-image.js
@@ -21,7 +21,7 @@ class RiseImage extends PolymerElement {
 
   static get properties() {
     return {
-      file: {
+      files: {
         type: String,
         value: ""
       },
@@ -68,6 +68,10 @@ class RiseImage extends PolymerElement {
     return "image-error";
   }
 
+  static get EVENT_IMAGE_RESET() {
+    return "image-reset";
+  }
+
   static get EVENT_SVG_USAGE() {
     return "svg-usage";
   }
@@ -93,8 +97,8 @@ class RiseImage extends PolymerElement {
 
     this._watchInitiated = false;
     this._initialStart = true;
-    this._invalidFileType = false;
-    this._url = "";
+    this._filesList = [];
+    this._temporaryFlag = false;
   }
 
   ready() {
@@ -125,16 +129,20 @@ class RiseImage extends PolymerElement {
     };
   }
 
-  _getStorageData() {
+  _getStorageData( file, url ) {
     return {
       configuration: "storage file",
-      file_form: this._getStorageFileFormat( this.file ),
-      file_path: this.file,
-      local_url: this._url
+      file_form: this._getStorageFileFormat( file ),
+      file_path: file,
+      local_url: url || ""
     }
   }
 
   _getStorageFileFormat( filePath ) {
+    if ( !filePath || typeof filePath !== "string" ) {
+      return "";
+    }
+
     return filePath.substr( filePath.lastIndexOf( "." ) + 1 ).toLowerCase();
   }
 
@@ -142,9 +150,9 @@ class RiseImage extends PolymerElement {
     if ( !this._initialStart ) {
 
       this._watchInitiated = false;
-      this._url = "";
+      this._filesList = [];
 
-      this._log( RiseImage.LOG_TYPE_INFO, "reset", null, { storage: this._getStorageData() });
+      this._log( RiseImage.LOG_TYPE_INFO, RiseImage.EVENT_IMAGE_RESET, { files: this.files });
       this._start();
     }
   }
@@ -163,7 +171,7 @@ class RiseImage extends PolymerElement {
     return false;
   }
 
-  _getDataUrlFromSVGLocalUrl( localUrl ) {
+  _getDataUrlFromSVGLocalUrl( file, localUrl ) {
     return new Promise(( resolve, reject ) => {
       const xhr = new XMLHttpRequest();
 
@@ -184,7 +192,7 @@ class RiseImage extends PolymerElement {
           this._log( RiseImage.LOG_TYPE_INFO, RiseImage.EVENT_SVG_USAGE, { svg_details: {
             blob_size: xhr.response.size,
             data_url_length: reader.result.length
-          } }, { storage: this._getStorageData() });
+          } }, { storage: this._getStorageData( file, localUrl ) });
 
           resolve( reader.result );
         };
@@ -202,19 +210,43 @@ class RiseImage extends PolymerElement {
     });
   }
 
-  _filterInvalidFileTypes() {
-    if ( this.file ) {
-      if ( !this._isValidFileType( this.file )) {
-        const errorMessage = "Invalid file format";
-
-        this._log( RiseImage.LOG_TYPE_ERROR, RiseImage.EVENT_IMAGE_ERROR, { errorMessage }, { storage: this._getStorageData() });
-        this._sendImageEvent( RiseImage.EVENT_IMAGE_ERROR, { file: this.file, errorMessage });
-        this._invalidFileType = true;
-      }
+  _isValidFiles( files ) {
+    if ( !files || typeof files !== "string" ) {
+      return false;
     }
+
+    // single symbol
+    if ( files.indexOf( "|" ) === -1 ) {
+      return true;
+    }
+
+    return files.split( "|" ).indexOf( "" ) === -1;
   }
 
-  _renderImage( url ) {
+  _filterInvalidFileTypes( files ) {
+    let invalidFiles = [];
+    const filteredFiles = files.filter( file => {
+      const valid = this._isValidFileType( file );
+
+      if ( !valid ) {
+        invalidFiles.push( file );
+      }
+
+      return valid;
+    });
+
+    invalidFiles.forEach( invalidFile => {
+      this._log( RiseImage.LOG_TYPE_ERROR, RiseImage.EVENT_IMAGE_ERROR, { errorMessage: "Invalid file format" }, { storage: this._getStorageData( invalidFile ) });
+    });
+
+    if ( !filteredFiles || filteredFiles.length === 0 ) {
+      this._sendImageEvent( RiseImage.EVENT_IMAGE_ERROR, { files, errorMessage: "All file formats are invalid" });
+    }
+
+    return filteredFiles;
+  }
+
+  _renderImage( file, url ) {
     if ( this.responsive ) {
       this.$.image.updateStyles({ "--iron-image-width": "100%" });
     } else {
@@ -223,14 +255,14 @@ class RiseImage extends PolymerElement {
       this.$.image.sizing = this.sizing;
     }
 
-    if ( this._getStorageFileFormat( this.file ) === "svg" ) {
-      this._getDataUrlFromSVGLocalUrl( url )
+    if ( this._getStorageFileFormat( file ) === "svg" ) {
+      this._getDataUrlFromSVGLocalUrl( file, url )
         .then( dataUrl => {
           this.$.image.src = dataUrl;
         })
         .catch( error => {
-          this._log( RiseImage.LOG_TYPE_ERROR, RiseImage.EVENT_IMAGE_ERROR, error, { storage: this._getStorageData() });
-          this._sendImageEvent( RiseImage.EVENT_IMAGE_ERROR, { file: this.file, error });
+          this._log( RiseImage.LOG_TYPE_ERROR, RiseImage.EVENT_IMAGE_ERROR, error, { storage: this._getStorageData( file, url ) });
+          this._sendImageEvent( RiseImage.EVENT_IMAGE_ERROR, { file: file, error });
         });
     } else {
       this.$.image.src = url;
@@ -242,9 +274,14 @@ class RiseImage extends PolymerElement {
   }
 
   _start() {
-    this._filterInvalidFileTypes();
+    if ( !this._isValidFiles()) {
+      this._clearImage();
+      return;
+    }
 
-    if ( !this.file || this._invalidFileType ) {
+    this._filesList = this._filterInvalidFileTypes( this.files.split( "|" ));
+
+    if ( !this._filesList || !this._filesList.length || this._filesList.length === 0 ) {
       this._clearImage();
       return;
     }
@@ -254,9 +291,12 @@ class RiseImage extends PolymerElement {
     }
 
     if ( !this._watchInitiated ) {
-      RisePlayerConfiguration.LocalStorage.watchSingleFile(
-        this.file, message => this._handleSingleFileUpdate( message )
-      );
+      this._filesList.forEach( file => {
+        RisePlayerConfiguration.LocalStorage.watchSingleFile(
+          file, message => this._handleSingleFileUpdate( message )
+        );
+      });
+
       this._watchInitiated = true;
     }
   }
@@ -264,8 +304,7 @@ class RiseImage extends PolymerElement {
   _handleStartForPreview() {
     // check license for preview will be implemented in some other epic later
 
-    this._url = RiseImage.STORAGE_PREFIX + this.file;
-    this._handleImageStatusUpdated( "CURRENT" );
+    // TODO: handling preview coming soon
   }
 
   _handleStart() {
@@ -273,7 +312,7 @@ class RiseImage extends PolymerElement {
       this._initialStart = false;
 
       if ( !RisePlayerConfiguration.isPreview()) {
-        this._log( RiseImage.LOG_TYPE_INFO, RiseImage.EVENT_START, null, { storage: this._getStorageData() });
+        this._log( RiseImage.LOG_TYPE_INFO, RiseImage.EVENT_START, { files: this.files });
       }
 
       this._start();
@@ -297,36 +336,43 @@ class RiseImage extends PolymerElement {
   }
 
   _handleSingleFileError( message ) {
-    const details = { file: this.file, errorMessage: message.errorMessage, errorDetail: message.errorDetail };
+    const details = { file: message.filePath, errorMessage: message.errorMessage, errorDetail: message.errorDetail };
 
     this._log( RiseImage.LOG_TYPE_ERROR, RiseImage.EVENT_IMAGE_ERROR, {
       errorMessage: message.errorMessage,
       errorDetail: message.errorDetail
-    }, { storage: this._getStorageData() });
+    }, { storage: this._getStorageData( message.filePath, message.fileUrl ) });
 
     this._sendImageEvent( RiseImage.EVENT_IMAGE_ERROR, details );
   }
 
   _handleSingleFileUpdate( message ) {
-    if ( !message.status ) {
+    if ( !message.status || !message.filePath ) {
       return;
     }
-
-    this._url = message.fileUrl || "";
 
     if ( message.status === "FILE-ERROR" ) {
       this._handleSingleFileError( message );
       return;
     }
 
-    this._handleImageStatusUpdated( message.status );
+    this._handleImageStatusUpdated( message );
   }
 
-  _handleImageStatusUpdated( status ) {
-    this._log( RiseImage.LOG_TYPE_INFO, RiseImage.EVENT_IMAGE_STATUS_UPDATED, { status: status }, { storage: this._getStorageData() });
+  _handleImageStatusUpdated( message ) {
+    this._log( RiseImage.LOG_TYPE_INFO, RiseImage.EVENT_IMAGE_STATUS_UPDATED, { status: message.status }, { storage: this._getStorageData( message.filePath, message.fileUrl ) });
 
-    if ( status === "CURRENT" ) {
-      this._renderImage( this._url );
+    if ( message.status === "CURRENT" ) {
+      // TODO: temporarily rendering only first image ready
+      console.log( message );
+      if ( !this._temporaryFlag ) {
+        this._temporaryFlag = true;
+        this._renderImage( message.filePath, message.fileUrl );
+      }
+    }
+
+    if ( message.status === "DELETED" ) {
+      // TODO: handle this when managing transitioning multiple files
     }
   }
 

--- a/src/rise-image.js
+++ b/src/rise-image.js
@@ -48,7 +48,7 @@ class RiseImage extends PolymerElement {
   // a comma-separated list of one or more dependencies.
   static get observers() {
     return [
-      "_reset(file)"
+      "_reset(files)"
     ]
   }
 
@@ -262,7 +262,7 @@ class RiseImage extends PolymerElement {
         })
         .catch( error => {
           this._log( RiseImage.LOG_TYPE_ERROR, RiseImage.EVENT_IMAGE_ERROR, error, { storage: this._getStorageData( file, url ) });
-          this._sendImageEvent( RiseImage.EVENT_IMAGE_ERROR, { file: file, error });
+          this._sendImageEvent( RiseImage.EVENT_IMAGE_ERROR, { file: file, errorMessage: error });
         });
     } else {
       this.$.image.src = url;
@@ -274,7 +274,7 @@ class RiseImage extends PolymerElement {
   }
 
   _start() {
-    if ( !this._isValidFiles()) {
+    if ( !this._isValidFiles( this.files )) {
       this._clearImage();
       return;
     }

--- a/test/index.html
+++ b/test/index.html
@@ -14,7 +14,8 @@
   /* global WCT */
   WCT.loadSuites([
     "unit/rise-image.html",
-    "integration/rise-image-logging.html"
+    "integration/rise-image-single.html",
+    "integration/rise-image-single-logging.html"
   ]);
 </script>
 </body>

--- a/test/index.html
+++ b/test/index.html
@@ -15,7 +15,7 @@
   WCT.loadSuites([
     "unit/rise-image.html",
     "integration/rise-image-single.html",
-    "integration/rise-image-single-logging.html"
+    "integration/rise-image-logging.html"
   ]);
 </script>
 </body>

--- a/test/integration/rise-image-logging.html
+++ b/test/integration/rise-image-logging.html
@@ -24,8 +24,12 @@
 <body>
 <test-fixture id="test-block">
     <template>
-        <rise-image id="test" sizing="contain"
-          file="risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/logo.png">
+        <rise-image
+          id="test"
+          width="300"
+          height="240"
+          sizing="contain"
+          files="risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/logo.png">
         </rise-image>
     </template>
 </test-fixture>
@@ -42,17 +46,14 @@
         file_form: "png",
         file_path: SAMPLE_PATH,
         local_url: ""
-      },
-      watchTimeoutDuration = 1000;
+      };
 
     let element;
 
     setup(() => {
       RisePlayerConfiguration.LocalStorage = {
         watchSingleFile: ( file, handler ) => {
-          setTimeout(
-            () => handler({ status: "CURRENT", fileUrl: SAMPLE_URL }), watchTimeoutDuration
-          );
+            handler({ status: "CURRENT", filePath: SAMPLE_PATH, fileUrl: SAMPLE_URL });
         }
       };
 
@@ -66,8 +67,7 @@
     });
 
     teardown(() => {
-      RisePlayerConfiguration.LocalStorage = {};
-      RisePlayerConfiguration.Logger = {};
+        RisePlayerConfiguration.Logger = {};
     });
 
     test( "should log 'start' event with correct params", () => {
@@ -75,111 +75,82 @@
 
       assert.deepEqual( RisePlayerConfiguration.Logger.info.args[ 0 ][ 0 ], componentData );
       assert.equal( RisePlayerConfiguration.Logger.info.args[ 0 ][ 1 ], "start");
-      assert.isNull( RisePlayerConfiguration.Logger.info.args[ 0 ][ 2 ] );
-      assert.deepEqual( RisePlayerConfiguration.Logger.info.args[ 0 ][ 3 ], {
-        storage: storageData
-      } );
+      assert.deepEqual( RisePlayerConfiguration.Logger.info.args[ 0 ][ 2 ], { files: SAMPLE_PATH } );
     });
 
-    test( "should log 'image-status-updated' event with correct params", done => {
+    test( "should log 'image-status-updated' event with correct params", () => {
       const storage = Object.assign({}, storageData);
       storage.local_url = SAMPLE_URL;
 
       element.dispatchEvent( new CustomEvent( "start" ));
 
-      setTimeout(() => {
-        assert.deepEqual( RisePlayerConfiguration.Logger.info.args[ 1 ][ 0 ], componentData );
-        assert.equal( RisePlayerConfiguration.Logger.info.args[ 1 ][ 1 ], "image-status-updated");
-        assert.deepEqual( RisePlayerConfiguration.Logger.info.args[ 1 ][ 2 ], { status: "CURRENT" });
-        assert.deepEqual( RisePlayerConfiguration.Logger.info.args[ 1 ][ 3 ], {
+      assert.deepEqual( RisePlayerConfiguration.Logger.info.args[ 1 ][ 0 ], componentData );
+      assert.equal( RisePlayerConfiguration.Logger.info.args[ 1 ][ 1 ], "image-status-updated");
+      assert.deepEqual( RisePlayerConfiguration.Logger.info.args[ 1 ][ 2 ], { status: "CURRENT" });
+      assert.deepEqual( RisePlayerConfiguration.Logger.info.args[ 1 ][ 3 ], {
           storage: storage
-        } );
-
-        done();
-      }, watchTimeoutDuration );
+      } );
     });
 
-    test( "should log an 'image-error' event when FILE-ERROR is received", done => {
+    test( "should log an 'image-error' event when FILE-ERROR is received", () => {
       RisePlayerConfiguration.LocalStorage.watchSingleFile = ( file, handler ) => {
-        setTimeout(
-          () => handler({
-            fileUrl: null,
-            status: "FILE-ERROR",
-            errorMessage: "image download error",
-            errorDetail: "network failure"
-          }), watchTimeoutDuration
-        );
+          handler({
+              filePath: SAMPLE_PATH,
+              fileUrl: null,
+              status: "FILE-ERROR",
+              errorMessage: "image download error",
+              errorDetail: "network failure"
+          });
       };
 
-      element.dispatchEvent( new CustomEvent( "start" ));
+        element.dispatchEvent( new CustomEvent( "start" ) );
 
-      setTimeout( () => {
         assert.equal( RisePlayerConfiguration.Logger.info.callCount, 1 ); // start
 
         assert.deepEqual( RisePlayerConfiguration.Logger.error.args[ 0 ][ 0 ], componentData );
         assert.equal( RisePlayerConfiguration.Logger.error.args[ 0 ][ 1 ], "image-error");
         assert.deepEqual( RisePlayerConfiguration.Logger.error.args[ 0 ][ 2 ], {
-          errorMessage: "image download error",
-          errorDetail: "network failure"
+            errorMessage: "image download error",
+            errorDetail: "network failure"
         });
-        assert.deepEqual( RisePlayerConfiguration.Logger.info.args[ 0 ][ 3 ], {
-          storage: storageData
+        assert.deepEqual( RisePlayerConfiguration.Logger.error.args[ 0 ][ 3 ], {
+            storage: storageData
         } );
-
-        done();
-      }, watchTimeoutDuration );
     });
 
-    test( "should log an 'image-error' event when file type is invalid", (done) => {
-        element.file = "risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/test.txt";
+    test( "should log an 'image-error' event when file type is invalid", () => {
+        element.files = "risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/test.txt";
 
-        setTimeout(()=>{
-            element.dispatchEvent( new CustomEvent( "start" ));
-
-            assert.equal( RisePlayerConfiguration.Logger.info.callCount, 1 ); // start
-
-            assert.deepEqual( RisePlayerConfiguration.Logger.error.args[ 0 ][ 0 ], componentData );
-            assert.equal( RisePlayerConfiguration.Logger.error.args[ 0 ][ 1 ], "image-error");
-            assert.deepEqual( RisePlayerConfiguration.Logger.error.args[ 0 ][ 2 ], {
-                errorMessage: "Invalid file format"
-            });
-            assert.deepEqual( RisePlayerConfiguration.Logger.info.args[ 0 ][ 3 ], {
-                storage: {
-                    configuration: "storage file",
-                    file_form: "txt",
-                    file_path: "risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/test.txt",
-                    local_url: ""
-                }
-            } );
-
-            done();
-        },200);
-
-
-    } );
-
-    test( "should log 'reset' info event", (done) => {
         element.dispatchEvent( new CustomEvent( "start" ));
 
-        setTimeout(() => {
-            sinon.stub( element, "_start" );
-            element.file = "risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/logo2.png";
+        assert.equal( RisePlayerConfiguration.Logger.info.callCount, 1 ); // start
 
-            assert.deepEqual( RisePlayerConfiguration.Logger.info.args[ 2 ][ 0 ], componentData );
-            assert.equal( RisePlayerConfiguration.Logger.info.args[ 2 ][ 1 ], "reset");
-            assert.isNull( RisePlayerConfiguration.Logger.info.args[ 2 ][ 2 ] );
-            assert.deepEqual( RisePlayerConfiguration.Logger.info.args[ 2 ][ 3 ], {
-                storage: {
-                    configuration: "storage file",
-                    file_form: "png",
-                    file_path: "risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/logo2.png",
-                    local_url: ""
-                }
-            } );
+        assert.deepEqual( RisePlayerConfiguration.Logger.error.args[ 0 ][ 0 ], componentData );
+        assert.equal( RisePlayerConfiguration.Logger.error.args[ 0 ][ 1 ], "image-error");
+        assert.deepEqual( RisePlayerConfiguration.Logger.error.args[ 0 ][ 2 ], {
+            errorMessage: "Invalid file format"
+        });
+        assert.deepEqual( RisePlayerConfiguration.Logger.error.args[ 0 ][ 3 ], {
+            storage: {
+                configuration: "storage file",
+                file_form: "txt",
+                file_path: "risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/test.txt",
+                local_url: ""
+            }
+        } );
+    } );
 
-            element._start.restore();
-            done();
-        }, watchTimeoutDuration );
+    test( "should log 'reset' info event", () => {
+        element.dispatchEvent( new CustomEvent( "start" ));
+
+        sinon.stub( element, "_start" );
+        element.files = "risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/logo2.png";
+
+        assert.deepEqual( RisePlayerConfiguration.Logger.info.args[ 2 ][ 0 ], componentData );
+        assert.equal( RisePlayerConfiguration.Logger.info.args[ 2 ][ 1 ], "image-reset");
+        assert.deepEqual( RisePlayerConfiguration.Logger.info.args[ 2 ][ 2 ], { files: "risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/logo2.png" } );
+
+        element._start.restore();
     } );
 
     test( "should log 'svg-usage' event with svg details", done => {
@@ -187,13 +158,11 @@
 
         RisePlayerConfiguration.LocalStorage = {
             watchSingleFile: ( file, handler ) => {
-                setTimeout(
-                  () => handler({ status: "CURRENT", fileUrl: `https://storage.googleapis.com/${filePath}` }), watchTimeoutDuration
-                );
+                handler({ status: "CURRENT", filePath, fileUrl: `https://storage.googleapis.com/${filePath}` });
             }
         };
 
-          element.file = "risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f/rise-image-demo/PokemonGO-Team-Logos-Instinct.svg";
+          element.files = filePath;
           element.dispatchEvent( new CustomEvent( "start" ));
 
           setTimeout(() => {
@@ -214,7 +183,7 @@
           }, 3000 );
     });
 
-    test("should log an 'image-error' when rendering an SVG file files", done => {
+    test("should log an 'image-error' when rendering an SVG file files", (done) => {
         sinon.stub(element, "_getDataUrlFromSVGLocalUrl").callsFake(() => {
             return Promise.reject("Request failed: 404: Not found");
         });
@@ -223,16 +192,14 @@
 
         RisePlayerConfiguration.LocalStorage = {
             watchSingleFile: ( file, handler ) => {
-                setTimeout(
-                  () => handler({ status: "CURRENT", fileUrl: `https://storage.googleapis.com/${filePath}` }), watchTimeoutDuration
-                );
+                handler({ status: "CURRENT", filePath, fileUrl: `https://storage.googleapis.com/${filePath}` });
             }
         };
 
-        element.file = "risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f/rise-image-demo/PokemonGO-Team-Logos-Instinct.svg";
+        element.files = "risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f/rise-image-demo/PokemonGO-Team-Logos-Instinct.svg";
         element.dispatchEvent( new CustomEvent( "start" ));
 
-        setTimeout(() => {
+        setTimeout( () => {
             assert.deepEqual( RisePlayerConfiguration.Logger.error.args[ 0 ][ 0 ], componentData );
             assert.equal( RisePlayerConfiguration.Logger.error.args[ 0 ][ 1 ], "image-error");
             assert.equal( RisePlayerConfiguration.Logger.error.args[ 0 ][ 2 ], "Request failed: 404: Not found");
@@ -246,9 +213,9 @@
             } );
 
             element._getDataUrlFromSVGLocalUrl.restore();
-            done();
-        }, watchTimeoutDuration );
 
+            done();
+        }, 1000 );
     })
 
   });

--- a/test/integration/rise-image-single.html
+++ b/test/integration/rise-image-single.html
@@ -71,7 +71,7 @@
       });
 
       test('it should clear image when file attribute is empty', () => {
-        let spy = sinon.spy( element, "_clearImage" );
+        let spy = sinon.spy( element, "_clearDisplayedImage" );
 
         element.files = "";
 
@@ -83,7 +83,7 @@
       });
 
       test('it should clear image when file type is invalid', () => {
-        let spy = sinon.spy( element, "_clearImage" );
+        let spy = sinon.spy( element, "_clearDisplayedImage" );
 
         element.files = "risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/test.txt";
 

--- a/test/integration/rise-image-single.html
+++ b/test/integration/rise-image-single.html
@@ -1,0 +1,187 @@
+<!doctype html>
+
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+  <script src="../../node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
+  <script src="../../node_modules/@polymer/test-fixture/test-fixture.js"></script>
+  <script src="../../node_modules/mocha/mocha.js"></script>
+  <script src="../../node_modules/chai/chai.js"></script>
+  <script src="../../node_modules/sinon/pkg/sinon.js"></script>
+  <script src="../../node_modules/wct-mocha/wct-mocha.js"></script>
+  <script>
+    const SAMPLE_PATH = 'risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/logo.png';
+    const SAMPLE_URL = `https://storage.googleapis.com/${ SAMPLE_PATH }`;
+
+    RisePlayerConfiguration = {
+      isPreview: () => false
+    };
+  </script>
+  <script src="../../src/rise-image.js" type="module"></script>
+</head>
+<body>
+<test-fixture id="test-block">
+  <template>
+    <rise-image
+      width="300"
+      height="240"
+      sizing="contain"
+      files="risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/logo.png">
+    </rise-image>
+  </template>
+</test-fixture>
+
+<script>
+  suite( "rise-image single file", () => {
+    let element;
+
+    setup(() => {
+      RisePlayerConfiguration.Logger = {
+        info: () => {},
+        warning: () => {},
+        error: () => {}
+      };
+
+      element = fixture("test-block");
+    });
+
+    teardown(() => {
+      RisePlayerConfiguration.Logger = {};
+    });
+
+    suite('render and clear image', () => {
+      setup(() => {
+        RisePlayerConfiguration.LocalStorage = {
+          watchSingleFile: (file, handler) => {
+            handler({ status: "CURRENT", filePath: SAMPLE_PATH, fileUrl: SAMPLE_URL });
+          }
+        };
+      });
+
+      teardown(() => {
+        RisePlayerConfiguration.LocalStorage = {};
+      });
+
+      test('it should render image when an image is available', () => {
+        element.dispatchEvent( new CustomEvent( "start" ) );
+
+        assert.equal(element.$.image.src, SAMPLE_URL);
+      });
+
+      test('it should clear image when file attribute is empty', () => {
+        let spy = sinon.spy( element, "_clearImage" );
+
+        element.files = "";
+
+        element.dispatchEvent( new CustomEvent( "start" ) );
+
+        assert(spy.called);
+
+        spy.restore();
+      });
+
+      test('it should clear image when file type is invalid', () => {
+        let spy = sinon.spy( element, "_clearImage" );
+
+        element.files = "risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/test.txt";
+
+        element.dispatchEvent( new CustomEvent( "start" ) );
+
+        assert(spy.called);
+
+        spy.restore();
+      });
+
+    });
+
+    suite('error', () => {
+      setup(() => {
+        RisePlayerConfiguration.LocalStorage = {
+          watchSingleFile: (file, handler) => {
+            handler({
+              filePath: "risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/logo.png",
+              fileUrl: null,
+              status: "FILE-ERROR",
+              errorMessage: "image download error",
+              errorDetail: "network failure"
+            });
+          }
+        };
+      });
+
+      test('it should send an image error event if an image local storage error was received', (done) => {
+        element.addEventListener('image-error', event => {
+          assert.deepEqual( event.detail, {
+            file: SAMPLE_PATH,
+            errorMessage: "image download error",
+            errorDetail: "network failure"
+          });
+
+          done();
+        });
+
+        element.dispatchEvent( new CustomEvent( "start" ) );
+      });
+
+      test('it should send an image error event when the single file type is invalid', done => {
+        element.addEventListener('image-error', event => {
+          assert.deepEqual( event.detail, {
+            files: [ "risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/test.txt" ],
+            errorMessage: "All file formats are invalid"
+          });
+
+          done();
+        });
+
+        element.files = "risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/test.txt";
+
+        element.dispatchEvent( new CustomEvent( "start" ) );
+      });
+
+      test("should send an image error event when failed to render an SVG file", done => {
+        const svgFilePath = "risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f/rise-image-demo/PokemonGO-Team-Logos-Instinct.svg",
+          svgFileUrl = `https://storage.googleapis.com/${svgFilePath}`;
+
+        sinon.stub(element, "_getDataUrlFromSVGLocalUrl").callsFake(() => {
+          return Promise.reject("Request failed: 404: Not found");
+        });
+
+        element.addEventListener('image-error', event => {
+          assert.deepEqual( event.detail, {
+            file: svgFilePath,
+            errorMessage: "Request failed: 404: Not found"
+          });
+
+          done();
+        });
+
+        RisePlayerConfiguration.LocalStorage = {
+          watchSingleFile: ( file, handler ) => {
+            handler({ status: "CURRENT", filePath: svgFilePath, fileUrl: svgFileUrl  });
+          }
+        };
+
+        element.files = svgFilePath;
+
+        element.dispatchEvent( new CustomEvent( "start" ) );
+      })
+    });
+
+    suite('rise-image on preview', () => {
+      setup(() => {
+        RisePlayerConfiguration.isPreview = () => true;
+      });
+
+      teardown(() => {
+        RisePlayerConfiguration.isPreview = () => false;
+      });
+
+      // TODO: add tests when supporting preview is ready
+    });
+  });
+
+</script>
+</body>
+</html>

--- a/test/unit/rise-image.html
+++ b/test/unit/rise-image.html
@@ -25,307 +25,202 @@
     <test-fixture id="test-block">
       <template>
         <rise-image
-          file="risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/logo.png">
+          width="300"
+          height="240"
+          sizing="contain"
+          files="risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/logo.png">
         </rise-image>
       </template>
     </test-fixture>
 
     <script>
-      suite('rise-image', () => {
+      suite( "rise-image", () => {
         let element;
 
         setup(() => {
-          RisePlayerConfiguration.LocalStorage = {
-            watchSingleFile: (file, handler) => {
-              setTimeout(
-                () => handler({ status: "CURRENT", fileUrl: SAMPLE_URL }), 1000
-              );
-            }
-          };
-
           RisePlayerConfiguration.Logger = {
             info: () => {},
-            error: () => {},
-            warning: () => {}
-          };
-
-          element = fixture('test-block');
-        });
-
-        teardown(() => {
-          RisePlayerConfiguration.LocalStorage = {};
-          RisePlayerConfiguration.Logger = {};
-        });
-
-        test('it should have a property "file"', () => {
-          assert.equal(element.file, SAMPLE_PATH);
-        });
-
-        test('it should render image when an image is available', (done) => {
-          element.addEventListener('configured', () =>
-            element.dispatchEvent( new CustomEvent( "start" ) )
-          );
-          element.dispatchEvent( new CustomEvent( "start" ) );
-
-          setTimeout( () => {
-            assert.equal(element._url, SAMPLE_URL);
-            assert.equal(element.$.image.src, SAMPLE_URL);
-
-            done();
-          }, 1000 );
-        });
-
-        test('it should clear image when file attribute is empty', () => {
-          let spy = sinon.spy( element, "_clearImage" );
-
-          element.file = "";
-
-          element.addEventListener('configured', () =>
-            element.dispatchEvent( new CustomEvent( "start" ) )
-          );
-          element.dispatchEvent( new CustomEvent( "start" ) );
-
-          assert(spy.called);
-
-          spy.restore();
-        });
-
-        test('it should clear image when file type is invalid', () => {
-          let spy = sinon.spy( element, "_clearImage" );
-
-          element.file = "risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/test.txt";
-
-          element.addEventListener('configured', () =>
-            element.dispatchEvent( new CustomEvent( "start" ) )
-          );
-          element.dispatchEvent( new CustomEvent( "start" ) );
-
-          assert(spy.called);
-
-          spy.restore();
-        });
-
-      });
-
-      suite('error', () => {
-        let element;
-
-        setup(() => {
-          RisePlayerConfiguration.LocalStorage = {
-            watchSingleFile: (file, handler) => {
-              setTimeout(
-                () => handler({
-                  fileUrl: null,
-                  status: "FILE-ERROR",
-                  errorMessage: "image download error",
-                  errorDetail: "network failure"
-                }), 1000
-              );
-            }
-          };
-
-          RisePlayerConfiguration.Logger = {
-            info: () => {},
-            error: () => {},
-            warning: () => {}
-          };
-
-          element = fixture('test-block');
-        });
-
-        teardown(() => {
-          RisePlayerConfiguration.LocalStorage = {};
-          RisePlayerConfiguration.Logger = {};
-        });
-
-        test('it should send an image error event if an image local storage error was received', done => {
-          element.addEventListener('image-error', event => {
-            assert(!element.url);
-
-            assert.deepEqual( event.detail, {
-              file: SAMPLE_PATH,
-              errorMessage: "image download error",
-              errorDetail: "network failure"
-            });
-
-            done();
-          });
-
-          element.addEventListener('configured', () =>
-            element.dispatchEvent( new CustomEvent( "start" ) )
-          );
-          element.dispatchEvent( new CustomEvent( "start" ) );
-        });
-
-        test('it should send an image error event when file type is invalid', done => {
-          element.addEventListener('image-error', event => {
-            assert(!element.url);
-
-            assert.deepEqual( event.detail, {
-              file: "risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/test.txt",
-              errorMessage: "Invalid file format"
-            });
-
-            done();
-          });
-
-          element.file = "risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/test.txt";
-
-          element.addEventListener('configured', () =>
-            element.dispatchEvent( new CustomEvent( "start" ) )
-          );
-          element.dispatchEvent( new CustomEvent( "start" ) );
-        });
-      });
-
-      suite( "_getStorageFileFormat", () => {
-        let element;
-
-        setup(() => {
-          RisePlayerConfiguration.LocalStorage = {
-            watchSingleFile: () => {}
-          };
-
-          RisePlayerConfiguration.Logger = {
-            info: () => {},
+            warning: () => {},
             error: () => {}
           };
 
-          element = fixture('test-block');
+          element = fixture("test-block");
         });
 
-        teardown(() => {
-          RisePlayerConfiguration.LocalStorage = {};
-          RisePlayerConfiguration.Logger = {};
-        });
+        suite( "_isValidFiles", () => {
+          test( "should return true if 'files' attribute is a non-empty String", () => {
+            assert.isTrue( element._isValidFiles( "test" ) );
+          } );
 
-        test( "should return correct format from file path", () => {
-          assert.equal( element._getStorageFileFormat( SAMPLE_PATH ), "png" );
-          assert.equal( element._getStorageFileFormat( "risemedialibrary-abc123/logo.jpg" ), "jpg" );
-          assert.equal( element._getStorageFileFormat( "risemedialibrary-abc123/logo.jpg.svg" ), "svg" );
-          assert.equal( element._getStorageFileFormat( "" ), "" );
-        } );
-      } );
+          test( "should return false if 'files' attribute is not a String or empty String", () => {
+            assert.isFalse( element._isValidFiles( 123 ) );
+            assert.isFalse( element._isValidFiles( ["test1|test2"] ) );
+            assert.isFalse( element._isValidFiles( "" ) );
+          } );
 
-      suite('rise-image on preview', () => {
-        let element;
+          test( "should return true if 'files' attribute is a String containing values separated by '|'", () => {
+            assert.isTrue( element._isValidFiles( "test1|test2|test3" ) );
+          } );
 
-        setup(() => {
-          RisePlayerConfiguration.isPreview = () => true;
-
-          RisePlayerConfiguration.Logger = {
-            info: () => {},
-            error: () => {}
-          };
-
-          element = fixture('test-block');
-        });
-
-        teardown(() => {
-          RisePlayerConfiguration.isPreview = () => false;
-
-          RisePlayerConfiguration.Logger = {};
-        });
-
-        test('it should render an image', done => {
-          element.addEventListener('configured', () =>
-            element.dispatchEvent( new CustomEvent( "start" ) )
-          );
-          element.dispatchEvent( new CustomEvent( "start" ) );
-
-          setTimeout( () => {
-            assert.equal(element._url, SAMPLE_URL);
-            assert.equal(element.$.image.src, SAMPLE_URL);
-
-            done();
-          }, 1000 );
-        });
-      });
-
-      suite( "_reset", () => {
-        let element,
-          startStub;
-
-        setup( () => {
-          RisePlayerConfiguration.Logger = {
-            info: () => {}
-          };
-
-          element = fixture('test-block');
-
-          startStub = sinon.stub( element, "_start" );
+          test( "should return false if 'files' attribute contains '|' with any empty value", () => {
+            assert.isFalse( element._isValidFiles( "test|" ) );
+            assert.isFalse( element._isValidFiles( "|test" ) );
+            assert.isFalse( element._isValidFiles( "|" ) );
+            assert.isFalse( element._isValidFiles( "test1|test2||test3" ) );
+          } );
         } );
 
-        teardown( () => {
-          RisePlayerConfiguration.Logger = {};
-          startStub.restore();
+        suite( "_getStorageFileFormat", () => {
+          test( "should return correct format from file path", () => {
+            assert.equal( element._getStorageFileFormat( SAMPLE_PATH ), "png" );
+            assert.equal( element._getStorageFileFormat( "risemedialibrary-abc123/logo.jpg" ), "jpg" );
+            assert.equal( element._getStorageFileFormat( "risemedialibrary-abc123/logo.jpg.svg" ), "svg" );
+            assert.equal( element._getStorageFileFormat( "" ), "" );
+          } );
         } );
 
-        test( "should call _start() if not initial start", () => {
-          // need to remove the stub and add back on every test
-          element._initialStart = false;
-          element._watchInitiated = true;
-          element._reset();
-
-          assert.isFalse( element._watchInitiated );
-          assert.isTrue( startStub.calledOnce );
-        } );
-
-      } );
-
-      suite( "_getDataUrlFromSVGLocalUrl", () => {
-
-        let element,
-          xhr,
-          requests;
-
-        setup( () => {
-          RisePlayerConfiguration.Logger = {
-            info: () => {}
-          };
-
-          element = fixture('test-block');
-
-          xhr = sinon.useFakeXMLHttpRequest();
-          requests = [];
-
-          xhr.onCreate = ( request ) => {
-            requests.push( request );
-          };
-        });
-
-        teardown( () => {
-          RisePlayerConfiguration.Logger = {};
-          xhr.restore();
-        });
-
-        test( "should get a data url response", function() {
-          const svg = `...`;
-          const blob = new Blob([svg], {type: 'image/svg+xml'});
-
-          let promise = element._getDataUrlFromSVGLocalUrl( "" )
-            .then( function( dataUrl ) {
-              assert( dataUrl );
-              assert.include( dataUrl, "data:image/svg+xml;base64");
-            });
-
-          requests[ 0 ].respond( 200, { "Content-Type": "blob" }, `${blob}` );
-
-          return promise;
-        });
-
-        test( "should return an error if xhr request fails", function() {
-          let promise = element._getDataUrlFromSVGLocalUrl( "" )
-            .catch( error => {
-              assert( error );
-              assert.include( error, "404" );
+        suite( "_getStorageData", () => {
+          test( "should return correct storage data", () => {
+            assert.deepEqual( element._getStorageData( "risemedialibrary-abc123/logo.jpg", "file:///path-to-file" ), {
+              configuration: "storage file",
+              file_form: "jpg",
+              file_path: "risemedialibrary-abc123/logo.jpg",
+              local_url: "file:///path-to-file"
             } );
+          } );
 
-          requests[ 0 ].respond( 404, {}, "" );
+          test( "should handle empty fileUrl value", () => {
+            assert.deepEqual( element._getStorageData( "risemedialibrary-abc123/logo.jpg" ), {
+              configuration: "storage file",
+              file_form: "jpg",
+              file_path: "risemedialibrary-abc123/logo.jpg",
+              local_url: ""
+            } );
+          } );
+        } );
 
-          return promise;
+        suite( "_getDataUrlFromSVGLocalUrl", () => {
+          let xhr,
+            requests;
+
+          setup( () => {
+            xhr = sinon.useFakeXMLHttpRequest();
+            requests = [];
+
+            xhr.onCreate = ( request ) => {
+              requests.push( request );
+            };
+          });
+
+          teardown( () => {
+            xhr.restore();
+          });
+
+          test( "should get a data url response", function() {
+            const svg = `...`;
+            const blob = new Blob([svg], {type: 'image/svg+xml'});
+
+            let promise = element._getDataUrlFromSVGLocalUrl( "" )
+              .then( function( dataUrl ) {
+                assert( dataUrl );
+                assert.include( dataUrl, "data:image/svg+xml;base64");
+              });
+
+            requests[ 0 ].respond( 200, { "Content-Type": "blob" }, `${blob}` );
+
+            return promise;
+          });
+
+          test( "should return an error if xhr request fails", function() {
+            let promise = element._getDataUrlFromSVGLocalUrl( "" )
+              .catch( error => {
+                assert( error );
+                assert.include( error, "404" );
+              } );
+
+            requests[ 0 ].respond( 404, {}, "" );
+
+            return promise;
+          });
+
         });
 
+        suite( "_filterInvalidFileTypes", () => {
+          test( "should return filtered files list", () => {
+            assert.deepEqual( element._filterInvalidFileTypes( [ "test1.jpg", "test2.gif", "test3.txt", "test4.png", "test5.webm" ] ), [
+              "test1.jpg", "test2.gif", "test4.png"
+            ] )
+          } );
+
+          test( "should return empty list", () => {
+            assert.deepEqual( element._filterInvalidFileTypes( [ "test1.webm", "test2.text", "test3.mov" ] ), [] );
+          } );
+        } );
+
+        suite( "_reset", () => {
+          let startStub;
+
+          setup( () => {
+            startStub = sinon.stub( element, "_start" );
+          } );
+
+          teardown( () => {
+            startStub.restore();
+          } );
+
+          test( "should call _start() if not initial start", () => {
+            element._initialStart = false;
+            element._watchInitiated = true;
+            element._filesList = [ SAMPLE_PATH ];
+            element._reset();
+
+            assert.isFalse( element._watchInitiated );
+            assert.isEmpty( element._filesList );
+            assert.isTrue( startStub.calledOnce );
+          } );
+
+        } );
+
+        suite( "_renderImage", () => {
+          setup( () => {
+            sinon.spy( element.$.image, "updateStyles" );
+            sinon.stub(element, "_getDataUrlFromSVGLocalUrl").callsFake(() => {
+              return Promise.resolve("dataurl");
+            });
+          } );
+
+          teardown( () => {
+            element.$.image.updateStyles.restore();
+            element._getDataUrlFromSVGLocalUrl.restore();
+          } );
+
+          test( "should ignore width/height/sizing and apply responsive styling", () => {
+            element.responsive = true;
+
+            element._renderImage( SAMPLE_PATH, SAMPLE_URL );
+
+            assert.isTrue(element.$.image.updateStyles.called);
+            assert.isNull(element.$.image.width);
+            assert.isNull(element.$.image.height);
+            assert.isNull(element.$.image.sizing);
+          } );
+
+          test( "should apply fixed width/height/sizing", () => {
+            element._renderImage( SAMPLE_PATH, SAMPLE_URL );
+
+            assert.isFalse(element.$.image.updateStyles.called);
+            assert.equal(element.$.image.width, 300);
+            assert.equal(element.$.image.height, 240);
+            assert.equal(element.$.image.sizing, "contain");
+
+          } );
+
+          test( "should attempt to get data url when format is SVG", () => {
+            element._renderImage( "risemedialibrary-abc123/test.svg", "https://storage.googleapis.com/risemedialibrary-abc123/test.svg" );
+
+            assert.isTrue( element._getDataUrlFromSVGLocalUrl.called );
+          } );
+        } );
       });
 
     </script>


### PR DESCRIPTION
- Revised attribute to `files`, string value of file paths separated by |
- Added `files` attribute validation
- Refactored logic in several areas to account for multiple files and ensuring to watch each file (post validation & filtering)
- Temporarily only rendering first received image, transition mechanism to follow later
- Removed any execution when detected running on Preview, this logic to follow later

Validated locally on the updated demo in this PR
![image](https://user-images.githubusercontent.com/7407007/57873230-99007d00-77db-11e9-949a-2f7068e0b961.png)
