### PR TITLE
E2e/deploy to versioned path

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -326,7 +326,6 @@ workflows:
             branches:
               only:
                 - master
-                - /^e2e[/].*/
       - deploy-production:
           stage: stable
           name: deploy-stable

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,9 +1,20 @@
 version: 2.1
 
 jobs:
-  install:
+  preconditions:
     docker: &BUILDIMAGE
-      - image: jenkinsrise/cci-v2-components:0.0.5
+      - image: jenkinsrise/cci-v2-components:0.0.4
+    steps:
+      - checkout
+      - run: |
+          if [ -z $(grep version package.json |grep -o '[0-9.]*') ]
+          then
+            echo Version must be specified in package.json
+            exit 1
+          fi
+
+  install:
+    docker: *BUILDIMAGE
     steps:
       - checkout
       - restore_cache:
@@ -186,15 +197,21 @@ jobs:
       - run: mkdir -p ~/.config
       - run: cp -r gcloud ~/.config
       - run: |
-          TARGET=$WIDGETS_BASE/<< parameters.stage >>/components/$COMPONENT_NAME/
-          echo Deploying << parameters.stage >> version of $COMPONENT_NAME
+          MAJOR=$(grep version package.json | grep -Po '[0-9]+' | head -1)
+          TARGET=$WIDGETS_BASE/<< parameters.stage >>/components/$COMPONENT_NAME/$MAJOR/
+          echo Deploying << parameters.stage >> version of $COMPONENT_NAME/$MAJOR
           node_modules/common-component/deploy-gcs.sh $COMPONENT_NAME $TARGET
 
 workflows:
   workflow1:
     jobs:
-      - install
+      - preconditions
+      - install:
+          requires:
+            - preconditions
       - gcloud-setup:
+          requires:
+            - preconditions
           filters:
             branches:
               only:
@@ -203,6 +220,8 @@ workflows:
                 - master
                 - build/stable
       - generate-version:
+          requires:
+            - preconditions
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 jobs:
   preconditions:
     docker: &BUILDIMAGE
-      - image: jenkinsrise/cci-v2-components:0.0.4
+      - image: jenkinsrise/cci-v2-components:0.0.5
     steps:
       - checkout
       - run: |
@@ -326,6 +326,7 @@ workflows:
             branches:
               only:
                 - master
+                - /^e2e[/].*/
       - deploy-production:
           stage: stable
           name: deploy-stable

--- a/demo/src/rise-image.html
+++ b/demo/src/rise-image.html
@@ -12,13 +12,15 @@
     <script type="module">
       // this and the following block are needed at build time to force the creation of the shared bundle script
       import { PolymerElement, html } from '@polymer/polymer/polymer-element.js';
+      import "@polymer/iron-image/iron-image.js";
     </script>
     <script type="module">
       import { PolymerElement, html } from '@polymer/polymer/polymer-element.js';
+      import "@polymer/iron-image/iron-image.js";
     </script>
     <script src="https://widgets.risevision.com/beta/common/config-test.min.js"></script>
     <script src="https://widgets.risevision.com/beta/common/common-template.min.js"></script>
-    <script src="https://widgets.risevision.com/beta/components/rise-image/rise-image.js"></script>
+    <script src="https://widgets.risevision.com/beta/components/rise-image/1/rise-image.js"></script>
     <script>
       if (document.domain.indexOf("localhost") === -1) {
         try {

--- a/e2e/rise-image.html
+++ b/e2e/rise-image.html
@@ -12,9 +12,11 @@
     <script type="module">
       // this and the following block are needed at build time to force the creation of the shared bundle script
       import { PolymerElement, html } from '@polymer/polymer/polymer-element.js';
+      import "@polymer/iron-image/iron-image.js";
     </script>
     <script type="module">
       import { PolymerElement, html } from '@polymer/polymer/polymer-element.js';
+      import "@polymer/iron-image/iron-image.js";
     </script>
     <script src="https://widgets.risevision.com/__STAGE__/common/config-test.min.js"></script>
     <script src="https://widgets.risevision.com/__STAGE__/common/common-template.min.js"></script>

--- a/html/index.html
+++ b/html/index.html
@@ -9,6 +9,7 @@
     <script type="module">
       // Basic noop script that helps forcing shared bundle file creation.
       import { PolymerElement } from '@polymer/polymer/polymer-element.js';
+      import "@polymer/iron-image/iron-image.js";
     </script>
     <script src="../src/rise-image.js" type="module"></script>
   </head>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-image",
-  "version": "0.0.1",
+  "version": "1.0.0",
   "description": "Web component built for Templates to display an image from Storage",
   "repository": "https://github.com/Rise-vision/rise-image.git",
   "bugs": {


### PR DESCRIPTION
@andrecardoso @olegrise @ezequielc @alex-deaconu @stulees @fjvallarino

These are the changes for rise-image component to create a versioned path for the component without web component dependencies, as discussed here: https://docs.google.com/document/d/1rnKfE1DhDQHWu8O1zfmoYn5uF5yqaq-wXe2A48tplJU/edit#heading=h.utvde6s4phvf

E2e tests were adjusted and ran fine. This was tested also with a similar version of rise-data-financial in this branch:
https://github.com/Rise-Vision/rise-data-financial/compare/e2e/deploy-to-versioned-path?expand=1

with the template in this branch:
https://github.com/Rise-Vision/html-template-library/compare/example-financial-template/fix/colliding-elements?expand=1

and worked fine using this schedule:
https://apps.risevision.com/schedules/details/710a1da0-8e90-43f4-9836-f8dfbdb03fae?cid=30007b45-3df0-4c7b-9f7f-7d8ce6443013

These changes ( mainly the CCI config for path publishing ) will also be applied to rise-text and rise-data-weather; and then the templates that use all these components will adjust the path to the components also ( just around 5 templates now ).
