### PR TITLE
Support transitioning multiple files

### DIFF
--- a/demo/src/rise-image.html
+++ b/demo/src/rise-image.html
@@ -77,8 +77,9 @@
     <rise-image
       id="rise-image-03"
       label="My Image"
+      duration="5"
       responsive
-      files="risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f/rise-image-demo/Pensive Parakeet.jpg|risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f/rise-image-demo/Boston City Flow.jpg">
+      files="risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f/rise-image-demo/Pensive Parakeet.jpg|risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f/rise-image-demo/Boston City Flow.jpg|risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f/rise-image-demo/canadiens_logo.gif|risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f/rise-image-demo/blue-jays-logo.jpg|risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f/rise-image-demo/raptors_logo.png">
     </rise-image>
   </div>
 

--- a/src/rise-image.js
+++ b/src/rise-image.js
@@ -366,7 +366,7 @@ class RiseImage extends PolymerElement {
     if ( status.toUpperCase() === "CURRENT" ) {
       if ( !managedFile ) {
         // get the order that this file should be in from _filesList
-        const order = this._filesList.findIndex( file => file.filePath === filePath );
+        const order = this._filesList.findIndex( path => path === filePath );
 
         managedFile = { filePath, fileUrl, order };
 

--- a/src/rise-image.js
+++ b/src/rise-image.js
@@ -315,7 +315,7 @@ class RiseImage extends PolymerElement {
     this.duration = parseInt( this.duration, 10 );
 
     if ( !isNaN( this.duration ) && this.duration !== 0 ) {
-      this._transitionTimer = timeOut.run( this._onShowImageComplete, this.duration );
+      this._transitionTimer = timeOut.run( this._onShowImageComplete.bind( this ), this.duration * 1000 );
     }
   }
 

--- a/src/rise-image.js
+++ b/src/rise-image.js
@@ -178,7 +178,8 @@ class RiseImage extends PolymerElement {
       this._managedFiles = [];
       this._managedFilesInError = [];
       this._filesToRenderList = [];
-      this._transitionIndex = null;
+      this._transitionTimer = null;
+      this._transitionIndex = 0;
 
       this._log( RiseImage.LOG_TYPE_INFO, RiseImage.EVENT_IMAGE_RESET, { files: this.files });
       this._start();

--- a/test/index.html
+++ b/test/index.html
@@ -15,6 +15,7 @@
   WCT.loadSuites([
     "unit/rise-image.html",
     "integration/rise-image-single.html",
+    "integration/rise-image-multiple.html",
     "integration/rise-image-logging.html"
   ]);
 </script>

--- a/test/integration/rise-image-multiple.html
+++ b/test/integration/rise-image-multiple.html
@@ -12,8 +12,20 @@
   <script src="../../node_modules/sinon/pkg/sinon.js"></script>
   <script src="../../node_modules/wct-mocha/wct-mocha.js"></script>
   <script>
-    const SAMPLE_PATH = 'risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/logo.png';
-    const SAMPLE_URL = `https://storage.googleapis.com/${ SAMPLE_PATH }`;
+    const testFiles = [
+      {
+        path: "risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f/rise-image-demo/canadiens_logo.gif",
+        url: "https://storage.googleapis.com/risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f/rise-image-demo/canadiens_logo.gif"
+      },
+      {
+        path: "risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f/rise-image-demo/blue-jays-logo.jpg",
+        url: "https://storage.googleapis.com/risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f/rise-image-demo/blue-jays-logo.jpg"
+      },
+      {
+        path: "risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f/rise-image-demo/raptors_logo.png",
+        url: "https://storage.googleapis.com/risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f/rise-image-demo/raptors_logo.png"
+      }
+    ];
 
     RisePlayerConfiguration = {
       isPreview: () => false
@@ -34,7 +46,8 @@
 
 <script>
   suite( "rise-image multiple files", () => {
-    let element;
+    let element,
+      clock;
 
     setup(() => {
       RisePlayerConfiguration.Logger = {
@@ -43,22 +56,271 @@
         error: () => {}
       };
 
+      clock = sinon.useFakeTimers();
+
       element = fixture("test-block");
     });
 
     teardown(() => {
+      clock.restore();
       RisePlayerConfiguration.Logger = {};
     });
 
     suite('transition images', () => {
       setup(() => {
-
+        RisePlayerConfiguration.LocalStorage = {
+          watchSingleFile: (filePath, handler) => {
+            const file = testFiles.find( file => file.path === filePath );
+            handler({ status: "CURRENT", filePath: file.path, fileUrl: file.url });
+          }
+        };
       });
 
       teardown(() => {
+        RisePlayerConfiguration.LocalStorage = {};
+      });
+
+      test('it should render first image when an image is available', () => {
+        element.dispatchEvent( new CustomEvent( "start" ) );
+
+        assert.equal(element.$.image.src, testFiles[ 0 ].url);
+      });
+
+      test('it should start transition timer when two images available and show each for 5 seconds', () => {
+        element.dispatchEvent( new CustomEvent( "start" ) );
+
+        assert.equal(element.$.image.src, testFiles[ 0 ].url);
+
+        clock.tick( 5000 );
+
+        assert.equal(element.$.image.src, testFiles[ 1 ].url);
+
+        clock.tick( 5000 );
+
+        assert.equal(element.$.image.src, testFiles[ 0 ].url);
+      });
+
+      test('it should transition all three images when all are available', () => {
+        element.dispatchEvent( new CustomEvent( "start" ) );
+
+        // emulate first two images cycle and first two images shown again in the following cycle
+        clock.tick( 20000 );
+
+        assert.equal(element.$.image.src, testFiles[ 2 ].url);
+
+        clock.tick( 5000 );
+
+        assert.equal(element.$.image.src, testFiles[ 0 ].url);
+      });
+
+    });
+
+    suite('error', () => {
+      setup(() => {
+        RisePlayerConfiguration.LocalStorage = {
+          watchSingleFile: (filePath, handler) => {
+            if ( filePath === testFiles[ 1 ].path ) {
+              handler({
+                filePath: testFiles[ 1 ].path,
+                fileUrl: null,
+                status: "FILE-ERROR",
+                errorMessage: "image download error",
+                errorDetail: "network failure"
+              });
+            } else {
+              const file = testFiles.find( file => file.path === filePath );
+              handler({ status: "CURRENT", filePath: file.path, fileUrl: file.url });
+            }
+          }
+        };
+      });
+
+      test('it should only cycle first and third test images', () => {
+        element.dispatchEvent( new CustomEvent( "start" ) );
+
+        assert.equal(element.$.image.src, testFiles[ 0 ].url);
+
+        clock.tick( 5000 );
+
+        assert.equal(element.$.image.src, testFiles[ 2 ].url);
+
+        clock.tick( 15000 );
+
+        assert.equal(element.$.image.src, testFiles[ 0 ].url);
+      });
+
+    });
+
+    suite('error when user updated file in Storage', () => {
+      setup(() => {
+        RisePlayerConfiguration.LocalStorage = {
+          watchSingleFile: (filePath, handler) => {
+            const file = testFiles.find( file => file.path === filePath );
+            handler({ status: "CURRENT", filePath: file.path, fileUrl: file.url });
+          }
+        };
+      });
+
+      test('it should transition all three images when all are available and then remove first file when error is received from RLS', () => {
+        element.dispatchEvent( new CustomEvent( "start" ) );
+
+        // emulate first two images cycle and first two images shown again in the following cycle
+        clock.tick( 20000 );
+
+        assert.equal(element.$.image.src, testFiles[ 2 ].url);
+
+        clock.tick( 5000 );
+
+        assert.equal(element.$.image.src, testFiles[ 0 ].url);
+
+        element._handleSingleFileUpdate( {
+          filePath: testFiles[ 0 ].path,
+          fileUrl: null,
+          status: "FILE-ERROR",
+          errorMessage: "image download error",
+          errorDetail: "network failure"
+
+        } );
+
+        // emulate cycling 2nd and third images, to be back to start again
+        clock.tick( 15000 );
+
+        // should be 2nd test image now that starts
+        assert.equal(element.$.image.src, testFiles[ 1 ].url);
+
+        clock.tick( 10000 );
+
+        assert.equal(element.$.image.src, testFiles[ 1 ].url);
+      });
+
+      test('it should transition all three images after file error is corrected', () => {
+        element.dispatchEvent( new CustomEvent( "start" ) );
+
+        // emulate first two images cycle and full following cycle
+        clock.tick( 25000 );
+
+        assert.equal(element.$.image.src, testFiles[ 0 ].url);
+
+        element._handleSingleFileUpdate( {
+          filePath: testFiles[ 0 ].path,
+          fileUrl: null,
+          status: "FILE-ERROR",
+          errorMessage: "image download error",
+          errorDetail: "network failure"
+
+        } );
+
+        // emulate cycling 2nd and third images, to be back to start again
+        clock.tick( 15000 );
+
+        // should be 2nd test image now that starts
+        assert.equal(element.$.image.src, testFiles[ 1 ].url);
+
+        // emulate file corrected
+        element._handleSingleFileUpdate( {
+          filePath: testFiles[ 0 ].path,
+          fileUrl: testFiles[ 0 ].url,
+          status: "CURRENT"
+        } );
+
+        clock.tick( 10000 );
+
+        // should be 1st test file that now starts
+        assert.equal(element.$.image.src, testFiles[ 0 ].url);
+
+        clock.tick( 15000 );
+
+        assert.equal(element.$.image.src, testFiles[ 0 ].url);
+      });
+
+      test('it should clear displayed image when error is received for all files from RLS', () => {
+        element.dispatchEvent( new CustomEvent( "start" ) );
+
+        // emulate first two images cycle and first two images shown again in the following cycle
+        clock.tick( 20000 );
+
+        assert.equal(element.$.image.src, testFiles[ 2 ].url);
+
+        clock.tick( 5000 );
+
+        assert.equal(element.$.image.src, testFiles[ 0 ].url);
+
+        element._handleSingleFileUpdate( {
+          filePath: testFiles[ 0 ].path,
+          fileUrl: null,
+          status: "FILE-ERROR",
+          errorMessage: "image download error",
+          errorDetail: "network failure"
+
+        } );
+
+        element._handleSingleFileUpdate( {
+          filePath: testFiles[ 1 ].path,
+          fileUrl: null,
+          status: "FILE-ERROR",
+          errorMessage: "image download error",
+          errorDetail: "network failure"
+
+        } );
+
+        element._handleSingleFileUpdate( {
+          filePath: testFiles[ 2 ].path,
+          fileUrl: null,
+          status: "FILE-ERROR",
+          errorMessage: "image download error",
+          errorDetail: "network failure"
+
+        } );
+
+        // emulate cycling 2nd and third images, to be back to start again
+        clock.tick( 15000 );
+
+        assert.equal(element.$.image.src, "");
 
       });
 
+    });
+
+    suite('user deleted file in Storage', () => {
+      setup(() => {
+        RisePlayerConfiguration.LocalStorage = {
+          watchSingleFile: (filePath, handler) => {
+            const file = testFiles.find( file => file.path === filePath );
+            handler({ status: "CURRENT", filePath: file.path, fileUrl: file.url });
+          }
+        };
+      });
+
+      test('it should transition all three images when all are available and then remove third file when DELETED is received from RLS', () => {
+        element.dispatchEvent( new CustomEvent( "start" ) );
+
+        // emulate first two images cycle and first two images shown again in the following cycle
+        clock.tick( 20000 );
+
+        assert.equal(element.$.image.src, testFiles[ 2 ].url);
+
+        clock.tick( 5000 );
+
+        assert.equal(element.$.image.src, testFiles[ 0 ].url);
+
+        element._handleSingleFileUpdate( {
+          filePath: testFiles[ 2 ].path,
+          status: "DELETED"
+        } );
+
+        // emulate cycling 2nd and third images, to be back to start again
+        clock.tick( 15000 );
+
+        assert.equal(element.$.image.src, testFiles[ 0 ].url);
+
+        clock.tick( 5000 );
+
+        assert.equal(element.$.image.src, testFiles[ 1 ].url);
+
+        clock.tick( 5000 );
+
+        assert.equal(element.$.image.src, testFiles[ 0 ].url);
+      });
     });
 
   });

--- a/test/integration/rise-image-multiple.html
+++ b/test/integration/rise-image-multiple.html
@@ -1,0 +1,68 @@
+<!doctype html>
+
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+  <script src="../../node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
+  <script src="../../node_modules/@polymer/test-fixture/test-fixture.js"></script>
+  <script src="../../node_modules/mocha/mocha.js"></script>
+  <script src="../../node_modules/chai/chai.js"></script>
+  <script src="../../node_modules/sinon/pkg/sinon.js"></script>
+  <script src="../../node_modules/wct-mocha/wct-mocha.js"></script>
+  <script>
+    const SAMPLE_PATH = 'risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/logo.png';
+    const SAMPLE_URL = `https://storage.googleapis.com/${ SAMPLE_PATH }`;
+
+    RisePlayerConfiguration = {
+      isPreview: () => false
+    };
+  </script>
+  <script src="../../src/rise-image.js" type="module"></script>
+</head>
+<body>
+<test-fixture id="test-block">
+  <template>
+    <rise-image
+      duration="5"
+      responsive
+      files="risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f/rise-image-demo/canadiens_logo.gif|risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f/rise-image-demo/blue-jays-logo.jpg|risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f/rise-image-demo/raptors_logo.png">
+    </rise-image>
+  </template>
+</test-fixture>
+
+<script>
+  suite( "rise-image multiple files", () => {
+    let element;
+
+    setup(() => {
+      RisePlayerConfiguration.Logger = {
+        info: () => {},
+        warning: () => {},
+        error: () => {}
+      };
+
+      element = fixture("test-block");
+    });
+
+    teardown(() => {
+      RisePlayerConfiguration.Logger = {};
+    });
+
+    suite('transition images', () => {
+      setup(() => {
+
+      });
+
+      teardown(() => {
+
+      });
+
+    });
+
+  });
+
+</script>
+</body>
+</html>

--- a/test/integration/rise-image-single.html
+++ b/test/integration/rise-image-single.html
@@ -70,26 +70,28 @@
         assert.equal(element.$.image.src, SAMPLE_URL);
       });
 
-      test('it should clear image when file attribute is empty', () => {
-        let spy = sinon.spy( element, "_clearDisplayedImage" );
+      test('it should not render image when file attribute is empty', () => {
+        let spy = sinon.spy( element, "_renderImage" );
 
         element.files = "";
 
         element.dispatchEvent( new CustomEvent( "start" ) );
 
-        assert(spy.called);
+        assert.isFalse(spy.called);
+        assert.equal(element.$.image.src, "");
 
         spy.restore();
       });
 
-      test('it should clear image when file type is invalid', () => {
-        let spy = sinon.spy( element, "_clearDisplayedImage" );
+      test('it should not render image when file type is invalid', () => {
+        let spy = sinon.spy( element, "_renderImage" );
 
         element.files = "risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/test.txt";
 
         element.dispatchEvent( new CustomEvent( "start" ) );
 
-        assert(spy.called);
+        assert.isFalse(spy.called);
+        assert.equal(element.$.image.src, "");
 
         spy.restore();
       });
@@ -114,7 +116,7 @@
       test('it should send an image error event if an image local storage error was received', (done) => {
         element.addEventListener('image-error', event => {
           assert.deepEqual( event.detail, {
-            file: SAMPLE_PATH,
+            filePath: SAMPLE_PATH,
             errorMessage: "image download error",
             errorDetail: "network failure"
           });
@@ -150,7 +152,7 @@
 
         element.addEventListener('image-error', event => {
           assert.deepEqual( event.detail, {
-            file: svgFilePath,
+            filePath: svgFilePath,
             errorMessage: "Request failed: 404: Not found"
           });
 

--- a/test/integration/rise-image-single.html
+++ b/test/integration/rise-image-single.html
@@ -51,7 +51,7 @@
       RisePlayerConfiguration.Logger = {};
     });
 
-    suite('render and clear image', () => {
+    suite('render image', () => {
       setup(() => {
         RisePlayerConfiguration.LocalStorage = {
           watchSingleFile: (file, handler) => {

--- a/test/unit/rise-image.html
+++ b/test/unit/rise-image.html
@@ -158,25 +158,36 @@
         } );
 
         suite( "_reset", () => {
-          let startStub;
-
           setup( () => {
-            startStub = sinon.stub( element, "_start" );
+            sinon.stub( element, "_start" );
           } );
 
           teardown( () => {
-            startStub.restore();
+            element._start.restore();
           } );
 
-          test( "should call _start() if not initial start", () => {
+          test( "should reset internals, clear displayed image, and call _start() only if not initial start", () => {
+            sinon.spy( element, "_clearDisplayedImage" );
+
             element._initialStart = false;
             element._watchInitiated = true;
             element._filesList = [ SAMPLE_PATH ];
+            element._managedFiles = [ { filePath: SAMPLE_PATH, fileUrl: SAMPLE_URL, order: 0 } ];
+            element._filesToRenderList = [ { filePath: SAMPLE_PATH, fileUrl: SAMPLE_URL, order: 0 } ];
+            element._managedFilesInError= [ { filePath: "test path", fileUrl: "test url", order: 1 } ];
+            element._transitionTimer = 12345;
+            element._transitionIndex = 3;
             element._reset();
 
             assert.isFalse( element._watchInitiated );
             assert.isEmpty( element._filesList );
-            assert.isTrue( startStub.calledOnce );
+            assert.isEmpty( element._managedFiles );
+            assert.isEmpty( element._managedFilesInError );
+            assert.isEmpty( element._filesToRenderList );
+            assert.isNull( element._transitionTimer );
+            assert.equal( element._transitionIndex, 0 );
+            assert.isTrue( element._clearDisplayedImage.called );
+            assert.isTrue( element._start.calledOnce );
           } );
 
         } );


### PR DESCRIPTION
- Transitions showing files based on `duration` property/attribute value (seconds), with a default value of 10 seconds
- Respects transitioning the images in the order of as defined from the `files` attribute
- Observes `duration` as well as `files` property, and ensures a complete _reset_ when either change value. This will involve cancelling a transition timer if one was running, clearing the image displayed, resetting all internal properties (i.e. file lists), and essentially starting again. 
- Handles RLS  FILE-ERROR as well as potential scenario of FILE-ERROR from user updating a file in Storage. Either case, the file is removed from the list of files to render/transition
- Handles a RLS DELETED message, the file is removed from the list of files to render/transition

Validated with an updated demo, video of demo transitioning can be seen here - https://www.screencast.com/t/JWR8nNyI