### PR TITLE
Support running in Preview

### DIFF
--- a/demo/package-lock.json
+++ b/demo/package-lock.json
@@ -4,6 +4,14 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@polymer/iron-image": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@polymer/iron-image/-/iron-image-3.0.2.tgz",
+      "integrity": "sha512-VyYtnewGozDb5sUeoLR1OvKzlt5WAL6b8Od7fPpio5oYL+9t061/nTV8+ZMrpMgF2WgB0zqM/3K53o3pbK5v8Q==",
+      "requires": {
+        "@polymer/polymer": "^3.0.0"
+      }
+    },
     "@polymer/polymer": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@polymer/polymer/-/polymer-3.1.0.tgz",

--- a/demo/package.json
+++ b/demo/package.json
@@ -4,6 +4,7 @@
   "license": "GPL-3.0+",
   "dependencies": {
     "@polymer/polymer": "3.1.0",
+    "@polymer/iron-image": "^3.0.1",
     "@webcomponents/webcomponentsjs": "^2.1.1"
   }
 }

--- a/demo/src/rise-image.html
+++ b/demo/src/rise-image.html
@@ -103,8 +103,11 @@
         console.log( "image 2 error", evt.detail );
       } );
 
-      // Uncomment the following line if the image component is marked as non-editable
-      // RisePlayerConfiguration.Helpers.sendStartEvent( image01 );
+      // Uncomment the following line if an image component instance is marked as non-editable
+      // RisePlayerConfiguration.Helpers.sendStartEvent( imageXX );
+
+      // Uncomment if testing directly in browser
+      // [ image01, image02, image03 ].forEach( el => RisePlayerConfiguration.Helpers.sendStartEvent( el ) );
     }
 
     window.addEventListener( "rise-components-ready", configureComponents );

--- a/src/rise-image.js
+++ b/src/rise-image.js
@@ -414,23 +414,28 @@ class RiseImage extends PolymerElement {
 
   _handleStartForPreview() {
     // check license for preview will be implemented in some other epic later
-
-    // TODO: handling preview coming soon
+    this._filesList.forEach( file => this._handleImageStatusUpdated({
+      filePath: file,
+      fileUrl: RiseImage.STORAGE_PREFIX + file,
+      status: "current"
+    }));
   }
 
   _handleStart() {
     if ( this._initialStart ) {
       this._initialStart = false;
 
-      if ( !RisePlayerConfiguration.isPreview()) {
-        this._log( RiseImage.LOG_TYPE_INFO, RiseImage.EVENT_START, { files: this.files });
-      }
+      this._log( RiseImage.LOG_TYPE_INFO, RiseImage.EVENT_START, { files: this.files });
 
       this._start();
     }
   }
 
   _log( type, event, details = null, additionalFields ) {
+    if ( RisePlayerConfiguration.isPreview()) {
+      return;
+    }
+
     const componentData = this._getComponentData();
 
     switch ( type ) {
@@ -495,7 +500,7 @@ class RiseImage extends PolymerElement {
       return;
     }
 
-    if ( message.status === "FILE-ERROR" ) {
+    if ( message.status.toUpperCase() === "FILE-ERROR" ) {
       this._handleSingleFileError( message );
       return;
     }
@@ -511,14 +516,14 @@ class RiseImage extends PolymerElement {
     this._manageFile( message );
     this._manageFileInError( message, true );
 
-    if ( this._filesToRenderList.length === 1 && status === "DELETED" && this._filesToRenderList.find( file => file.filePath === filePath )) {
+    if ( this._filesToRenderList.length === 1 && status.toUpperCase() === "DELETED" && this._filesToRenderList.find( file => file.filePath === filePath )) {
       this._filesToRenderList = [];
       this._clearDisplayedImage();
 
       return;
     }
 
-    if ( this._filesToRenderList.length < 2 && status === "CURRENT" ) {
+    if ( this._filesToRenderList.length < 2 && status.toUpperCase() === "CURRENT" ) {
       this._configureShowingImages();
     }
   }

--- a/src/rise-image.js
+++ b/src/rise-image.js
@@ -125,8 +125,13 @@ class RiseImage extends PolymerElement {
   }
 
   _configureImageEventListeners() {
-    this.$.image.addEventListener( "error-changed", ( evt ) => {
-      console.log( evt );
+    this.$.image.addEventListener( "error-changed", () => {
+      const filePath = this._filesToRenderList[ this._transitionIndex ].filePath,
+        fileUrl = this._filesToRenderList[ this._transitionIndex ].fileUrl,
+        errorMessage = "image failed to load";
+
+      this._log( RiseImage.LOG_TYPE_ERROR, RiseImage.EVENT_IMAGE_ERROR, errorMessage, { storage: this._getStorageData( filePath, fileUrl ) });
+      this._sendImageEvent( RiseImage.EVENT_IMAGE_ERROR, { filePath, errorMessage });
     });
   }
 

--- a/src/rise-image.js
+++ b/src/rise-image.js
@@ -462,6 +462,8 @@ class RiseImage extends PolymerElement {
       fileInError = this._getManagedFileInError( filePath );
 
     // prevent repetitive logging when component instance is receiving messages from other potential component instances watching same file
+    // Note: to avoid using Lodash or Underscore library for just a .isEqual() function, taking a simple approach to object comparison with JSON.stringify()
+    // as the property order will not change and the data is not large for this object
     if ( fileInError && ( JSON.stringify( details ) === JSON.stringify( fileInError.details ))) {
       return;
     }

--- a/test/integration/rise-image-multiple.html
+++ b/test/integration/rise-image-multiple.html
@@ -323,6 +323,57 @@
       });
     });
 
+    suite('running on preview or directly in browser', () => {
+      setup(() => {
+        RisePlayerConfiguration.isPreview = () => true;
+        RisePlayerConfiguration.LocalStorage = {
+          watchSingleFile: (filePath, handler) => {
+            const file = testFiles.find( file => file.path === filePath );
+            handler({ status: "CURRENT", filePath: file.path, fileUrl: file.url });
+          }
+        };
+      });
+
+      teardown(() => {
+        RisePlayerConfiguration.isPreview = () => false;
+        RisePlayerConfiguration.LocalStorage = {};
+      });
+
+      test('it should render first image', () => {
+        element.dispatchEvent( new CustomEvent( "start" ) );
+
+        assert.equal(element.$.image.src, testFiles[ 0 ].url);
+      });
+
+      test('it should start transition timer for two images and show each for 5 seconds', () => {
+        element.dispatchEvent( new CustomEvent( "start" ) );
+
+        assert.equal(element.$.image.src, testFiles[ 0 ].url);
+
+        clock.tick( 5000 );
+
+        assert.equal(element.$.image.src, testFiles[ 1 ].url);
+
+        clock.tick( 5000 );
+
+        assert.equal(element.$.image.src, testFiles[ 0 ].url);
+      });
+
+      test('it should transition all three images', () => {
+        element.dispatchEvent( new CustomEvent( "start" ) );
+
+        // emulate first two images cycle and first two images shown again in the following cycle
+        clock.tick( 20000 );
+
+        assert.equal(element.$.image.src, testFiles[ 2 ].url);
+
+        clock.tick( 5000 );
+
+        assert.equal(element.$.image.src, testFiles[ 0 ].url);
+      });
+
+    });
+
   });
 
 </script>

--- a/test/integration/rise-image-multiple.html
+++ b/test/integration/rise-image-multiple.html
@@ -326,17 +326,10 @@
     suite('running on preview or directly in browser', () => {
       setup(() => {
         RisePlayerConfiguration.isPreview = () => true;
-        RisePlayerConfiguration.LocalStorage = {
-          watchSingleFile: (filePath, handler) => {
-            const file = testFiles.find( file => file.path === filePath );
-            handler({ status: "CURRENT", filePath: file.path, fileUrl: file.url });
-          }
-        };
       });
 
       teardown(() => {
         RisePlayerConfiguration.isPreview = () => false;
-        RisePlayerConfiguration.LocalStorage = {};
       });
 
       test('it should render first image', () => {

--- a/test/integration/rise-image-single.html
+++ b/test/integration/rise-image-single.html
@@ -171,7 +171,7 @@
       })
     });
 
-    suite('rise-image on preview', () => {
+    suite('running on preview or directly in browser', () => {
       setup(() => {
         RisePlayerConfiguration.isPreview = () => true;
       });
@@ -180,7 +180,12 @@
         RisePlayerConfiguration.isPreview = () => false;
       });
 
-      // TODO: add tests when supporting preview is ready
+      test('it should render image', () => {
+        element.dispatchEvent( new CustomEvent( "start" ) );
+
+        assert.equal(element.$.image.src, SAMPLE_URL);
+      });
+
     });
   });
 

--- a/test/unit/rise-image.html
+++ b/test/unit/rise-image.html
@@ -232,6 +232,50 @@
             assert.isTrue( element._getDataUrlFromSVGLocalUrl.called );
           } );
         } );
+
+        suite( "_handleStartForPreview", () => {
+          setup( () => {
+            sinon.stub(element, "_handleImageStatusUpdated");
+          });
+
+          teardown( () => {
+            element._handleImageStatusUpdated.restore();
+          } );
+
+          test( "should call _handleImageStatusUpdated with correct data", () => {
+            element._filesList = [ "risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/logo.png" ];
+            element._handleStartForPreview();
+
+            assert.isTrue( element._handleImageStatusUpdated.calledWith({
+              filePath: "risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/logo.png",
+              fileUrl: "https://storage.googleapis.com/risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/logo.png",
+              status: "current"
+            } ));
+          } );
+
+          test( "should call _handleImageStatusUpdated for each file", () => {
+            element._filesList = [ "risemedialibrary-abc123/test1.png", "risemedialibrary-abc123/test2.png", "risemedialibrary-abc123/test3.png" ];
+            element._handleStartForPreview();
+
+            assert.deepEqual( element._handleImageStatusUpdated.args[0][0], {
+              filePath: "risemedialibrary-abc123/test1.png",
+              fileUrl: "https://storage.googleapis.com/risemedialibrary-abc123/test1.png",
+              status: "current"
+            } );
+
+            assert.deepEqual( element._handleImageStatusUpdated.args[1][0], {
+              filePath: "risemedialibrary-abc123/test2.png",
+              fileUrl: "https://storage.googleapis.com/risemedialibrary-abc123/test2.png",
+              status: "current"
+            } );
+
+            assert.deepEqual( element._handleImageStatusUpdated.args[2][0], {
+              filePath: "risemedialibrary-abc123/test3.png",
+              fileUrl: "https://storage.googleapis.com/risemedialibrary-abc123/test3.png",
+              status: "current"
+            } );
+          } );
+        } );
       });
 
     </script>


### PR DESCRIPTION
- As per the design, direct requests are made to GCS for the file(s) 
- All logic and flow of multiple image transitioning is no different for running in Preview
- Now logging and sending an event when an image fails to load
- Demo updated to test and to show how the use of `RisePlayerConfiguration.Helpers.sendStartEvent()` on all component instances can enable testing a HTML template directly in browser. To test directly in browser, the HTML page must run on a local web server. Details of running a local web server will be provided in README. 

Validated directly in browser with the demo, video capture can be seen [here](https://www.screencast.com/t/P4G6AnTBAR)