### PR TITLE
Revise event names for logging to BQ

### DIFF
--- a/src/rise-image.js
+++ b/src/rise-image.js
@@ -520,9 +520,7 @@ class RiseImage extends PolymerElement {
   }
 
   _handleImageStatusUpdated( message ) {
-    const { filePath, status, fileUrl } = message;
-
-    this._log( RiseImage.LOG_TYPE_INFO, RiseImage.EVENT_IMAGE_STATUS_UPDATED, { status }, { storage: this._getStorageData( filePath, fileUrl ) });
+    const { filePath, status } = message;
 
     this._manageFile( message );
     this._manageFileInError( message, true );

--- a/src/rise-image.js
+++ b/src/rise-image.js
@@ -126,12 +126,16 @@ class RiseImage extends PolymerElement {
 
   _configureImageEventListeners() {
     this.$.image.addEventListener( "error-changed", () => {
-      const filePath = this._filesToRenderList[ this._transitionIndex ].filePath,
-        fileUrl = this._filesToRenderList[ this._transitionIndex ].fileUrl,
-        errorMessage = "image failed to load";
+      // to prevent test coverage failing
+      if ( this._filesToRenderList.length === 0 ) {
+        return;
+      }
 
-      this._log( RiseImage.LOG_TYPE_ERROR, RiseImage.EVENT_IMAGE_ERROR, errorMessage, { storage: this._getStorageData( filePath, fileUrl ) });
-      this._sendImageEvent( RiseImage.EVENT_IMAGE_ERROR, { filePath, errorMessage });
+      const filePath = this._filesToRenderList[ this._transitionIndex ].filePath,
+        fileUrl = this._filesToRenderList[ this._transitionIndex ].fileUrl;
+
+      this._log( RiseImage.LOG_TYPE_ERROR, "image-load-fail", null, { storage: this._getStorageData( filePath, fileUrl ) });
+      this._sendImageEvent( RiseImage.EVENT_IMAGE_ERROR, { filePath, errorMessage: "image load failed" });
     });
   }
 
@@ -270,7 +274,7 @@ class RiseImage extends PolymerElement {
     });
 
     invalidFiles.forEach( invalidFile => {
-      this._log( RiseImage.LOG_TYPE_ERROR, RiseImage.EVENT_IMAGE_ERROR, { errorMessage: "Invalid file format" }, { storage: this._getStorageData( invalidFile ) });
+      this._log( RiseImage.LOG_TYPE_ERROR, "image-format-invalid", null, { storage: this._getStorageData( invalidFile ) });
     });
 
     if ( !filteredFiles || filteredFiles.length === 0 ) {
@@ -295,7 +299,7 @@ class RiseImage extends PolymerElement {
           this.$.image.src = dataUrl;
         })
         .catch( error => {
-          this._log( RiseImage.LOG_TYPE_ERROR, RiseImage.EVENT_IMAGE_ERROR, error, { storage: this._getStorageData( filePath, fileUrl ) });
+          this._log( RiseImage.LOG_TYPE_ERROR, "image-svg-fail", error, { storage: this._getStorageData( filePath, fileUrl ) });
           this._sendImageEvent( RiseImage.EVENT_IMAGE_ERROR, { filePath, errorMessage: error });
         });
     } else {
@@ -483,7 +487,7 @@ class RiseImage extends PolymerElement {
       "Invalid response with status code [CODE]"
      */
 
-    this._log( RiseImage.LOG_TYPE_ERROR, RiseImage.EVENT_IMAGE_ERROR, {
+    this._log( RiseImage.LOG_TYPE_ERROR, "image-rls-error", {
       errorMessage: message.errorMessage,
       errorDetail: message.errorDetail
     }, { storage: this._getStorageData( filePath, fileUrl ) });

--- a/test/integration/rise-image-logging.html
+++ b/test/integration/rise-image-logging.html
@@ -92,7 +92,7 @@
       } );
     });
 
-    test( "should log an 'image-error' event when FILE-ERROR is received", () => {
+    test( "should log an 'image-rls-error' event when FILE-ERROR is received", () => {
       RisePlayerConfiguration.LocalStorage.watchSingleFile = ( file, handler ) => {
           handler({
               filePath: SAMPLE_PATH,
@@ -108,7 +108,7 @@
         assert.equal( RisePlayerConfiguration.Logger.info.callCount, 1 ); // start
 
         assert.deepEqual( RisePlayerConfiguration.Logger.error.args[ 0 ][ 0 ], componentData );
-        assert.equal( RisePlayerConfiguration.Logger.error.args[ 0 ][ 1 ], "image-error");
+        assert.equal( RisePlayerConfiguration.Logger.error.args[ 0 ][ 1 ], "image-rls-error");
         assert.deepEqual( RisePlayerConfiguration.Logger.error.args[ 0 ][ 2 ], {
             errorMessage: "image download error",
             errorDetail: "network failure"
@@ -118,7 +118,7 @@
         } );
     });
 
-    test( "should log an 'image-error' event when file type is invalid", () => {
+    test( "should log an 'image-format-invalid' event when file type is invalid", () => {
         element.files = "risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/test.txt";
 
         element.dispatchEvent( new CustomEvent( "start" ));
@@ -126,10 +126,8 @@
         assert.equal( RisePlayerConfiguration.Logger.info.callCount, 1 ); // start
 
         assert.deepEqual( RisePlayerConfiguration.Logger.error.args[ 0 ][ 0 ], componentData );
-        assert.equal( RisePlayerConfiguration.Logger.error.args[ 0 ][ 1 ], "image-error");
-        assert.deepEqual( RisePlayerConfiguration.Logger.error.args[ 0 ][ 2 ], {
-            errorMessage: "Invalid file format"
-        });
+        assert.equal( RisePlayerConfiguration.Logger.error.args[ 0 ][ 1 ], "image-format-invalid");
+        assert.isNull( RisePlayerConfiguration.Logger.error.args[ 0 ][ 2 ]);
         assert.deepEqual( RisePlayerConfiguration.Logger.error.args[ 0 ][ 3 ], {
             storage: {
                 configuration: "storage file",
@@ -183,7 +181,7 @@
           }, 3000 );
     });
 
-    test("should log an 'image-error' when rendering an SVG file files", (done) => {
+    test("should log an 'image-svg-fail' when rendering an SVG file", (done) => {
         sinon.stub(element, "_getDataUrlFromSVGLocalUrl").callsFake(() => {
             return Promise.reject("Request failed: 404: Not found");
         });
@@ -201,7 +199,7 @@
 
         setTimeout( () => {
             assert.deepEqual( RisePlayerConfiguration.Logger.error.args[ 0 ][ 0 ], componentData );
-            assert.equal( RisePlayerConfiguration.Logger.error.args[ 0 ][ 1 ], "image-error");
+            assert.equal( RisePlayerConfiguration.Logger.error.args[ 0 ][ 1 ], "image-svg-fail");
             assert.equal( RisePlayerConfiguration.Logger.error.args[ 0 ][ 2 ], "Request failed: 404: Not found");
             assert.deepEqual( RisePlayerConfiguration.Logger.error.args[ 0 ][ 3 ], {
                 storage: {

--- a/test/integration/rise-image-logging.html
+++ b/test/integration/rise-image-logging.html
@@ -78,20 +78,6 @@
       assert.deepEqual( RisePlayerConfiguration.Logger.info.args[ 0 ][ 2 ], { files: SAMPLE_PATH } );
     });
 
-    test( "should log 'image-status-updated' event with correct params", () => {
-      const storage = Object.assign({}, storageData);
-      storage.local_url = SAMPLE_URL;
-
-      element.dispatchEvent( new CustomEvent( "start" ));
-
-      assert.deepEqual( RisePlayerConfiguration.Logger.info.args[ 1 ][ 0 ], componentData );
-      assert.equal( RisePlayerConfiguration.Logger.info.args[ 1 ][ 1 ], "image-status-updated");
-      assert.deepEqual( RisePlayerConfiguration.Logger.info.args[ 1 ][ 2 ], { status: "CURRENT" });
-      assert.deepEqual( RisePlayerConfiguration.Logger.info.args[ 1 ][ 3 ], {
-          storage: storage
-      } );
-    });
-
     test( "should log an 'image-rls-error' event when FILE-ERROR is received", () => {
       RisePlayerConfiguration.LocalStorage.watchSingleFile = ( file, handler ) => {
           handler({
@@ -144,9 +130,9 @@
         sinon.stub( element, "_start" );
         element.files = "risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/logo2.png";
 
-        assert.deepEqual( RisePlayerConfiguration.Logger.info.args[ 2 ][ 0 ], componentData );
-        assert.equal( RisePlayerConfiguration.Logger.info.args[ 2 ][ 1 ], "image-reset");
-        assert.deepEqual( RisePlayerConfiguration.Logger.info.args[ 2 ][ 2 ], { files: "risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/logo2.png" } );
+        assert.deepEqual( RisePlayerConfiguration.Logger.info.args[ 1 ][ 0 ], componentData );
+        assert.equal( RisePlayerConfiguration.Logger.info.args[ 1 ][ 1 ], "image-reset");
+        assert.deepEqual( RisePlayerConfiguration.Logger.info.args[ 1 ][ 2 ], { files: "risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/logo2.png" } );
 
         element._start.restore();
     } );
@@ -164,11 +150,11 @@
           element.dispatchEvent( new CustomEvent( "start" ));
 
           setTimeout(() => {
-              assert.deepEqual( RisePlayerConfiguration.Logger.info.args[ 2 ][ 0 ], componentData );
-              assert.equal( RisePlayerConfiguration.Logger.info.args[ 2 ][ 1 ], "svg-usage");
-              assert.property( RisePlayerConfiguration.Logger.info.args[ 2 ][ 2 ].svg_details, "blob_size");
-              assert.property( RisePlayerConfiguration.Logger.info.args[ 2 ][ 2 ].svg_details, "data_url_length");
-              assert.deepEqual( RisePlayerConfiguration.Logger.info.args[ 2 ][ 3 ], {
+              assert.deepEqual( RisePlayerConfiguration.Logger.info.args[ 1 ][ 0 ], componentData );
+              assert.equal( RisePlayerConfiguration.Logger.info.args[ 1 ][ 1 ], "svg-usage");
+              assert.property( RisePlayerConfiguration.Logger.info.args[ 1 ][ 2 ].svg_details, "blob_size");
+              assert.property( RisePlayerConfiguration.Logger.info.args[ 1 ][ 2 ].svg_details, "data_url_length");
+              assert.deepEqual( RisePlayerConfiguration.Logger.info.args[ 1 ][ 3 ], {
                   storage: {
                       configuration: "storage file",
                       file_form: "svg",


### PR DESCRIPTION
- Using specific event name values when logging to BQ to support categorizing reliability analysis
- Removed logging _image-status-updated_ event, reasoning is:
  - there are already RLS logs in BQ for file change status
  - when an instance is configured for many images, that event would be logged for each one when the component first starts, causing more pollution than value in BQ