### PR TITLE
Hide iron-image element when clearing its src

### DIFF
--- a/src/rise-image.js
+++ b/src/rise-image.js
@@ -269,8 +269,9 @@ class RiseImage extends RiseElement {
 
   _renderImage( filePath, fileUrl ) {
     if ( this.responsive ) {
-      this.$.image.updateStyles({ "--iron-image-width": "100%", "width": "100%", "height": "auto" });
+      this.$.image.updateStyles({ "--iron-image-width": "100%", "width": "100%", "height": "auto", "display": "inline-block" });
     } else {
+      this.$.image.updateStyles({ "display": "inline-block" });
       this.$.image.width = isNaN( this.width ) ? parseInt( this.width, 10 ) : this.width;
       this.$.image.height = isNaN( this.height ) ? parseInt( this.height, 10 ) : this.height;
       this.$.image.sizing = this.sizing;
@@ -293,6 +294,7 @@ class RiseImage extends RiseElement {
 
   _clearDisplayedImage() {
     this.$.image.src = "";
+    this.$.image.updateStyles({ "display": "none" });
   }
 
   _onShowImageComplete() {

--- a/test/unit/rise-image.html
+++ b/test/unit/rise-image.html
@@ -212,7 +212,7 @@
 
             element._renderImage( SAMPLE_PATH, SAMPLE_URL );
 
-            assert.isTrue(element.$.image.updateStyles.called);
+            assert.isTrue(element.$.image.updateStyles.calledWith({ "--iron-image-width": "100%", "width": "100%", "height": "auto", "display": "inline-block" }));
             assert.equal(element.$.image.style.width, "100%");
             assert.equal(element.$.image.style.height, "auto");
             assert.equal(getComputedStyle(element.$.image).getPropertyValue("--iron-image-width"), "100%");
@@ -225,7 +225,7 @@
           test( "should apply fixed width/height/sizing/position", () => {
             element._renderImage( SAMPLE_PATH, SAMPLE_URL );
 
-            assert.isFalse(element.$.image.updateStyles.called);
+            assert.isTrue(element.$.image.updateStyles.calledWith({"display": "inline-block"}));
             assert.equal(element.$.image.width, 300);
             assert.equal(element.$.image.height, 240);
             assert.equal(element.$.image.sizing, "contain");


### PR DESCRIPTION
- Fixes issue https://github.com/Rise-Vision/rise-vision-apps/issues/1060 
- Ensures to apply the `inline-block` value for css `display` style to iron-image instance when rendering an image to account for scenario of image being removed and then added again
- Validated works as expected on Windows 10 x32 with an updated stable version of _QA Image Component_ template that targets a staging version of this component with the fix. Presentation used for validation here - https://apps.risevision.com/templates/edit/c6af3f3e-c077-49a9-b22b-db840e87ae07/?cid=7fa5ee92-7deb-450b-a8d5-e5ed648c575f
