### PR TITLE
Fix/issue 1066 preview shows deleted images

### DIFF
--- a/src/rise-image.js
+++ b/src/rise-image.js
@@ -1,4 +1,4 @@
-/* eslint-disable no-console */
+/* eslint-disable no-console, one-var */
 
 import { RiseElement } from "rise-common-component/src/rise-element.js";
 import { html } from "@polymer/polymer/lib/utils/html-tag.js";
@@ -25,6 +25,10 @@ class RiseImage extends RiseElement {
       files: {
         type: String,
         value: ""
+      },
+      metadata: {
+        type: Array,
+        value: []
       },
       width: {
         type: String,
@@ -57,7 +61,7 @@ class RiseImage extends RiseElement {
   // a comma-separated list of one or more dependencies.
   static get observers() {
     return [
-      "_reset(files, duration)"
+      "_reset(files, metadata, duration)"
     ]
   }
 
@@ -434,12 +438,24 @@ class RiseImage extends RiseElement {
     this._transitionIndex = 0;
   }
 
+  _previewStatusFor( file ) {
+    // Metadata may not be present if no data updates have been received yet.
+    const hasMetadata = this.metadata && this.metadata.length > 0;
+
+    if ( !hasMetadata ) {
+      return "current";
+    }
+
+    const entry = this.metadata.find( current => current.file === file );
+
+    return entry && entry.exists ? "current" : "deleted";
+  }
+
   _handleStartForPreview() {
-    // check license for preview will be implemented in some other epic later
     this._filesList.forEach( file => this._handleImageStatusUpdated({
       filePath: file,
       fileUrl: RiseImage.STORAGE_PREFIX + file,
-      status: "current"
+      status: this._previewStatusFor( file )
     }));
   }
 

--- a/test/unit/rise-image.html
+++ b/test/unit/rise-image.html
@@ -339,26 +339,26 @@
         suite( "Play Unitl Done", () => {
 
           suite( "_isDone()", () => {
-    
+
             test("should return false when element is not configured for PUD", () => {
               assert.isFalse( element._isDone());
             });
 
             test("should return true when element is configured for PUD and transition index is last element", () => {
               element.setAttribute( "play-until-done", true);
-              
+
               element._transitionIndex = 0;
               element._filesToRenderList = [{"filePath":"risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f/DSC01624.JPG"}];
-              
+
               assert.isTrue( element._isDone());
             });
 
             test("should return false when element is configured for PUD and transition index is not last element", () => {
               element.setAttribute( "play-until-done", true);
-              
+
               element._transitionIndex = 0;
               element._filesToRenderList = [{ filePath: "risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f/DSC01624.JPG"}, { filePath: "risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/logo.png"}];
-              
+
               assert.isFalse( element._isDone());
             });
 
@@ -374,10 +374,10 @@
             teardown( () => {
               sandbox.restore();
             });
-    
+
             test("should send report-done event when it is done", () => {
               element.setAttribute( "play-until-done", true);
-              
+
               element._transitionIndex = 0;
               element._filesToRenderList = [{ filePath: "risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f/DSC01624.JPG"}];
 
@@ -398,10 +398,10 @@
             teardown( () => {
               sandbox.restore();
             });
-    
+
             test("should start empty play until done timer on empty files list", () => {
               element.setAttribute( "play-until-done", true);
-              
+
               element.files = "";
 
               element._start();
@@ -411,7 +411,7 @@
 
             test("should start empty play until done timer on invalid files list", () => {
               element.setAttribute( "play-until-done", true);
-              
+
               element.files = "risemedialibrary-abc123/README.md";
 
               element._start();
@@ -420,12 +420,60 @@
             });
 
           });
-          
+
+        });
+
+        suite( "_previewStatusFor", () => {
+          test( "should get current status if there is no metadata", () => {
+            element.metadata = [];
+
+            const status = element._previewStatusFor( 'risemedialibrary-abc123/README.md' );
+
+            assert.equal( status, "current" );
+          });
+
+          test( "should get current status if metadata says that file exists", () => {
+            element.metadata = [{
+           		"file": "risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f/apache.png",
+           		"exists": true
+           	}, {
+           		"file": "risemedialibrary-abc123/README.md",
+           		"exists": true
+           	}];
+
+            const status = element._previewStatusFor( 'risemedialibrary-abc123/README.md' );
+
+            assert.equal( status, "current" );
+          });
+
+          test( "should get deleted status if metadata says that file doesn't exist", () => {
+            element.metadata = [{
+           		"file": "risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f/apache.png",
+           		"exists": true
+           	}, {
+           		"file": "risemedialibrary-abc123/README.md",
+           		"exists": false
+           	}];
+
+            const status = element._previewStatusFor( 'risemedialibrary-abc123/README.md' );
+
+            assert.equal( status, "deleted" );
+          });
+
+          test( "should get deleted status if metadata is not empty but does not contain the file", () => {
+            element.metadata = [{
+           		"file": "risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f/apache.png",
+           		"exists": true
+           	}];
+
+            const status = element._previewStatusFor( 'risemedialibrary-abc123/README.md' );
+
+            assert.equal( status, "deleted" );
+          } );
+
         });
 
       });
-
-     
 
     </script>
   </body>

--- a/test/unit/rise-image.html
+++ b/test/unit/rise-image.html
@@ -434,12 +434,12 @@
 
           test( "should get current status if metadata says that file exists", () => {
             element.metadata = [{
-           		"file": "risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f/apache.png",
-           		"exists": true
-           	}, {
-           		"file": "risemedialibrary-abc123/README.md",
-           		"exists": true
-           	}];
+              "file": "risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f/apache.png",
+              "exists": true
+            }, {
+              "file": "risemedialibrary-abc123/README.md",
+              "exists": true
+            }];
 
             const status = element._previewStatusFor( 'risemedialibrary-abc123/README.md' );
 
@@ -448,12 +448,12 @@
 
           test( "should get deleted status if metadata says that file doesn't exist", () => {
             element.metadata = [{
-           		"file": "risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f/apache.png",
-           		"exists": true
-           	}, {
-           		"file": "risemedialibrary-abc123/README.md",
-           		"exists": false
-           	}];
+              "file": "risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f/apache.png",
+              "exists": true
+            }, {
+              "file": "risemedialibrary-abc123/README.md",
+              "exists": false
+            }];
 
             const status = element._previewStatusFor( 'risemedialibrary-abc123/README.md' );
 
@@ -462,9 +462,9 @@
 
           test( "should get deleted status if metadata is not empty but does not contain the file", () => {
             element.metadata = [{
-           		"file": "risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f/apache.png",
-           		"exists": true
-           	}];
+              "file": "risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f/apache.png",
+              "exists": true
+            }];
 
             const status = element._previewStatusFor( 'risemedialibrary-abc123/README.md' );
 


### PR DESCRIPTION
This fixes https://github.com/Rise-Vision/rise-vision-apps/issues/1066

Basically, in preview we check if the image is reported as non-existent in the metadata before displaying it. We already have metadata available in the template page, but the component had no use for it so it wasn't recognizing it. I'm adding it as a property now.

 Validation: https://apps-stage-9.risevision.com/templates/edit/46841dc1-efef-4a2d-84c9-1e0a14932ff4/?cid=cf85e5c4-9439-40ce-94d6-e5ea6ea2411c

The deleted image no longer shows in preview.

To reproduce from scratch create a new presentation from example-financial-template, configure an image, then delete that image in storage, and in the presentation go back to the component list and then again to the attribute editor for that image, so existence is checked again. Preview won't show the image now.

@willread FYI, when we open PR for fixes, we provide links and steps so others can validate that the solution is working.
