### PR TITLE
Convert files attribute to Array and support backwards compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ There is no need to configure listeners if the component runs as editable ( defa
     <div id="image-sample-container">
       <rise-image
         id="rise-image-sample"
-        files="risemedialibrary-abc123/file1.png|risemedialibrary-abc123/file2.png|risemedialibrary-abc123/file3.png"
+        files='["risemedialibrary-abc123/file1.png", "risemedialibrary-abc123/file2.png", "risemedialibrary-abc123/file3.png"]'
         duration="5"
         responsive>
       </rise-image>
@@ -39,7 +39,7 @@ This attribute holds a literal value, for example:
 ```
   <rise-image id="rise-image-sample"
     label="Sample"
-    files="risemedialibrary-abc123/logo.png">
+    files='["risemedialibrary-abc123/logo.png"]'>
   </rise-image>
 ```
 
@@ -51,7 +51,7 @@ This component receives the following list of attributes:
 
 - **id**: ( string / required ): Unique HTML id with format 'rise-image-<NAME_OR_NUMBER>'.
 - **label**: ( string ): An optional label key for the text that will appear in the template editor. See 'Labels' section above.
-- **files** ( string / required ): List of image file paths separated by pipe symbol. A file path must be a valid GCS file path. A folder path will not be valid. For example, this is a default folder path from Rise Storage:
+- **files** ( array / required ): List of image file paths applied in JSON format (see [Polymer documentation](https://polymer-library.polymer-project.org/3.0/docs/devguide/properties#configuring-object-and-array-properties) for configuring Array properties). A file path must be a valid GCS file path. A folder path will not be valid. For example, this is a default folder path from Rise Storage:
 https://storage.googleapis.com/risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f/Template%20Library/Global%20Assets/logo-white.png.
 To create a valid GCS path, remove *https://storage.googleapis.com/* and replace *%20* with a space.
 The resulting GCS path is: risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f/Template Library/Global Assets/logo-white.png.

--- a/demo/src/rise-image.html
+++ b/demo/src/rise-image.html
@@ -76,7 +76,7 @@
       id="rise-image-01"
       label="My Image"
       responsive
-      files="risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f/rise-image-demo/Costa Rican Frog.jpg">
+      files='["risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f/rise-image-demo/Costa Rican Frog.jpg"]'>
     </rise-image>
   </div>
 
@@ -88,7 +88,7 @@
       width="300"
       height="200"
       sizing="contain"
-      files="risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f/rise-image-demo/PokemonGO-Team-Logos-Instinct.svg">
+      files='["risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f/rise-image-demo/PokemonGO-Team-Logos-Instinct.svg"]'>
     </rise-image>
   </div>
 
@@ -99,7 +99,7 @@
       label="My Image"
       duration="5"
       responsive
-      files="risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f/rise-image-demo/Pensive Parakeet.jpg|risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f/rise-image-demo/Boston City Flow.jpg|risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f/rise-image-demo/canadiens_logo.gif|risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f/rise-image-demo/blue-jays-logo.jpg|risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f/rise-image-demo/raptors_logo.png">
+      files='["risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f/rise-image-demo/Pensive Parakeet.jpg","risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f/rise-image-demo/Boston City Flow.jpg", "risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f/rise-image-demo/canadiens_logo.gif", "risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f/rise-image-demo/blue-jays-logo.jpg", "risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f/rise-image-demo/raptors_logo.png"]'>
     </rise-image>
   </div>
 
@@ -112,7 +112,7 @@
       height="200"
       sizing="contain"
       position="top right"
-      files="risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f/rise-image-demo/kcu_logo.png">
+      files='["risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f/rise-image-demo/kcu_logo.png"]'>
     </rise-image>
   </div>
 

--- a/src/rise-image.js
+++ b/src/rise-image.js
@@ -23,8 +23,10 @@ class RiseImage extends RiseElement {
   static get properties() {
     return {
       files: {
-        type: String,
-        value: ""
+        type: Array,
+        value: () => {
+          return [];
+        }
       },
       metadata: {
         type: Array,
@@ -114,6 +116,14 @@ class RiseImage extends RiseElement {
 
     this.addEventListener( "rise-presentation-play", () => this._reset());
     this.addEventListener( "rise-presentation-stop", () => this._stop());
+  }
+
+  _deserializeValue( value, type ) {
+    if ( type === Array && value.charAt( 0 ) !== "[" && value.charAt( value.length - 1 ) !== "]" ) {
+      return this._convertFilesStringToArray( value );
+    } else {
+      return super._deserializeValue( value, type );
+    }
   }
 
   _configureImageEventListeners() {
@@ -229,17 +239,21 @@ class RiseImage extends RiseElement {
     });
   }
 
-  _isValidFiles( files ) {
-    if ( !files || typeof files !== "string" ) {
+  _convertFilesStringToArray( files ) {
+    // single file
+    if ( files.indexOf( "|" ) === -1 ) {
+      return [ files ];
+    }
+
+    return files.split( "|" );
+  }
+
+  _isValidFiles() {
+    if ( !this.files ) {
       return false;
     }
 
-    // single symbol
-    if ( files.indexOf( "|" ) === -1 ) {
-      return true;
-    }
-
-    return files.split( "|" ).indexOf( "" ) === -1;
+    return this.files.length > 0 && this.files.indexOf( "" ) === -1;
   }
 
   _filterInvalidFileTypes( files ) {
@@ -400,11 +414,11 @@ class RiseImage extends RiseElement {
   }
 
   _start() {
-    if ( !this._isValidFiles( this.files )) {
+    if ( !this._isValidFiles()) {
       return this._startEmptyPlayUntilDoneTimer();
     }
 
-    this._filesList = this._filterInvalidFileTypes( this.files.split( "|" ));
+    this._filesList = this._filterInvalidFileTypes( this.files );
 
     if ( !this._filesList || !this._filesList.length || this._filesList.length === 0 ) {
       return this._startEmptyPlayUntilDoneTimer();

--- a/src/rise-image.js
+++ b/src/rise-image.js
@@ -248,12 +248,12 @@ class RiseImage extends RiseElement {
     return files.split( "|" );
   }
 
-  _isValidFiles() {
-    if ( !this.files ) {
+  _isValidFiles( files ) {
+    if ( !files || !Array.isArray( files )) {
       return false;
     }
 
-    return this.files.length > 0 && this.files.indexOf( "" ) === -1;
+    return files.length > 0 && files.indexOf( "" ) === -1;
   }
 
   _filterInvalidFileTypes( files ) {
@@ -414,7 +414,7 @@ class RiseImage extends RiseElement {
   }
 
   _start() {
-    if ( !this._isValidFiles()) {
+    if ( !this._isValidFiles( this.files )) {
       return this._startEmptyPlayUntilDoneTimer();
     }
 

--- a/src/rise-image.js
+++ b/src/rise-image.js
@@ -468,7 +468,7 @@ class RiseImage extends RiseElement {
   _handleStartForPreview() {
     this._filesList.forEach( file => this._handleImageStatusUpdated({
       filePath: file,
-      fileUrl: RiseImage.STORAGE_PREFIX + file,
+      fileUrl: RiseImage.STORAGE_PREFIX + encodeURIComponent( file ),
       status: this._previewStatusFor( file )
     }));
   }

--- a/test/integration/rise-image-logging.html
+++ b/test/integration/rise-image-logging.html
@@ -31,7 +31,7 @@
           height="240"
           sizing="contain"
           position="top"
-          files="risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/logo.png">
+          files='["risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/logo.png"]'>
         </rise-image>
     </template>
 </test-fixture>
@@ -77,7 +77,7 @@
 
       assert.deepEqual( RisePlayerConfiguration.Logger.info.args[ 0 ][ 0 ], componentData );
       assert.equal( RisePlayerConfiguration.Logger.info.args[ 0 ][ 1 ], "start");
-      assert.deepEqual( RisePlayerConfiguration.Logger.info.args[ 0 ][ 2 ], { files: SAMPLE_PATH } );
+      assert.deepEqual( RisePlayerConfiguration.Logger.info.args[ 0 ][ 2 ], { files: [SAMPLE_PATH] } );
     });
 
     test( "should log an 'image-rls-error' event when FILE-ERROR is received", () => {
@@ -107,7 +107,7 @@
     });
 
     test( "should log an 'image-format-invalid' event when file type is invalid", () => {
-        element.files = "risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/test.txt";
+        element.files = ["risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/test.txt"];
 
         element.dispatchEvent( new CustomEvent( "start" ));
 
@@ -130,11 +130,11 @@
         element.dispatchEvent( new CustomEvent( "start" ));
 
         sinon.stub( element, "_start" );
-        element.files = "risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/logo2.png";
+        element.files = ["risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/logo2.png"];
 
         assert.deepEqual( RisePlayerConfiguration.Logger.info.args[ 1 ][ 0 ], componentData );
         assert.equal( RisePlayerConfiguration.Logger.info.args[ 1 ][ 1 ], "image-reset");
-        assert.deepEqual( RisePlayerConfiguration.Logger.info.args[ 1 ][ 2 ], { files: "risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/logo2.png" } );
+        assert.deepEqual( RisePlayerConfiguration.Logger.info.args[ 1 ][ 2 ], { files: ["risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/logo2.png"] } );
 
         element._start.restore();
     } );
@@ -148,7 +148,7 @@
             }
         };
 
-          element.files = filePath;
+          element.files = [filePath];
           element.dispatchEvent( new CustomEvent( "start" ));
 
           setTimeout(() => {
@@ -182,7 +182,7 @@
             }
         };
 
-        element.files = "risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f/rise-image-demo/PokemonGO-Team-Logos-Instinct.svg";
+        element.files = ["risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f/rise-image-demo/PokemonGO-Team-Logos-Instinct.svg"];
         element.dispatchEvent( new CustomEvent( "start" ));
 
         setTimeout( () => {

--- a/test/integration/rise-image-multiple.html
+++ b/test/integration/rise-image-multiple.html
@@ -40,7 +40,7 @@
     <rise-image
       duration="5"
       responsive
-      files="risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f/rise-image-demo/canadiens_logo.gif|risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f/rise-image-demo/blue-jays-logo.jpg|risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f/rise-image-demo/raptors_logo.png">
+      files='["risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f/rise-image-demo/canadiens_logo.gif","risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f/rise-image-demo/blue-jays-logo.jpg","risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f/rise-image-demo/raptors_logo.png"]'>
     </rise-image>
   </template>
 </test-fixture>

--- a/test/integration/rise-image-multiple.html
+++ b/test/integration/rise-image-multiple.html
@@ -336,21 +336,21 @@
       test('it should render first image', () => {
         element.dispatchEvent( new CustomEvent( "start" ) );
 
-        assert.equal(element.$.image.src, testFiles[ 0 ].url);
+        assert.equal(element.$.image.src, `https://storage.googleapis.com/${ encodeURIComponent( testFiles[ 0 ].path )}`);
       });
 
       test('it should start transition timer for two images and show each for 5 seconds', () => {
         element.dispatchEvent( new CustomEvent( "start" ) );
 
-        assert.equal(element.$.image.src, testFiles[ 0 ].url);
+        assert.equal(element.$.image.src, `https://storage.googleapis.com/${ encodeURIComponent( testFiles[ 0 ].path )}`);
 
         clock.tick( 5000 );
 
-        assert.equal(element.$.image.src, testFiles[ 1 ].url);
+        assert.equal(element.$.image.src, `https://storage.googleapis.com/${ encodeURIComponent( testFiles[ 1 ].path )}`);
 
         clock.tick( 5000 );
 
-        assert.equal(element.$.image.src, testFiles[ 2 ].url);
+        assert.equal(element.$.image.src, `https://storage.googleapis.com/${ encodeURIComponent( testFiles[ 2 ].path )}`);
       });
 
       test('it should transition all three images', () => {
@@ -359,11 +359,11 @@
         // emulate first two images cycle and first two images shown again in the following cycle
         clock.tick( 20000 );
 
-        assert.equal(element.$.image.src, testFiles[ 1 ].url);
+        assert.equal(element.$.image.src, `https://storage.googleapis.com/${ encodeURIComponent( testFiles[ 1 ].path )}`);
 
         clock.tick( 5000 );
 
-        assert.equal(element.$.image.src, testFiles[ 2 ].url);
+        assert.equal(element.$.image.src, `https://storage.googleapis.com/${ encodeURIComponent( testFiles[ 2 ].path )}`);
       });
 
     });

--- a/test/integration/rise-image-single.html
+++ b/test/integration/rise-image-single.html
@@ -30,7 +30,7 @@
       height="240"
       sizing="contain"
       position="top"
-      files="risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/logo.png">
+      files='["risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/logo.png"]'>
     </rise-image>
   </template>
 </test-fixture>
@@ -88,7 +88,7 @@
       test('it should not render image when file type is invalid', () => {
         let spy = sinon.spy( element, "_renderImage" );
 
-        element.files = "risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/test.txt";
+        element.files = ["risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/test.txt"];
 
         element.dispatchEvent( new CustomEvent( "start" ) );
 
@@ -139,7 +139,7 @@
           done();
         });
 
-        element.files = "risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/test.txt";
+        element.files = ["risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/test.txt"];
 
         element.dispatchEvent( new CustomEvent( "start" ) );
       });
@@ -167,7 +167,7 @@
           }
         };
 
-        element.files = svgFilePath;
+        element.files = [svgFilePath];
 
         element.dispatchEvent( new CustomEvent( "start" ) );
       })

--- a/test/integration/rise-image-single.html
+++ b/test/integration/rise-image-single.html
@@ -185,7 +185,7 @@
       test('it should render image', () => {
         element.dispatchEvent( new CustomEvent( "start" ) );
 
-        assert.equal(element.$.image.src, SAMPLE_URL);
+        assert.equal(element.$.image.src, `https://storage.googleapis.com/${ encodeURIComponent( SAMPLE_PATH )}`);
       });
 
     });

--- a/test/unit/rise-image.html
+++ b/test/unit/rise-image.html
@@ -30,7 +30,7 @@
           height="240"
           sizing="contain"
           position="top"
-          files="risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/logo.png">
+          files='["risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/logo.png"]'>
         </rise-image>
       </template>
     </test-fixture>
@@ -50,25 +50,17 @@
         });
 
         suite( "_isValidFiles", () => {
-          test( "should return true if 'files' attribute is a non-empty String", () => {
-            assert.isTrue( element._isValidFiles( "test" ) );
+          test( "should return true if 'files' attribute is not empty", () => {
+            assert.isTrue( element._isValidFiles( ["test1.jpg", "test2.jpg"] ) );
           } );
 
-          test( "should return false if 'files' attribute is not a String or empty String", () => {
-            assert.isFalse( element._isValidFiles( 123 ) );
-            assert.isFalse( element._isValidFiles( ["test1|test2"] ) );
+          test( "should return false if 'files' attribute is empty or is an empty Array", () => {
+            assert.isFalse( element._isValidFiles( [] ) );
             assert.isFalse( element._isValidFiles( "" ) );
           } );
 
-          test( "should return true if 'files' attribute is a String containing values separated by '|'", () => {
-            assert.isTrue( element._isValidFiles( "test1|test2|test3" ) );
-          } );
-
-          test( "should return false if 'files' attribute contains '|' with any empty value", () => {
-            assert.isFalse( element._isValidFiles( "test|" ) );
-            assert.isFalse( element._isValidFiles( "|test" ) );
-            assert.isFalse( element._isValidFiles( "|" ) );
-            assert.isFalse( element._isValidFiles( "test1|test2||test3" ) );
+          test( "should return false if 'files' attribute contains an item with an empty value", () => {
+            assert.isFalse( element._isValidFiles( ["test1.jpg","", "test2.jpg"] ) );
           } );
         } );
 
@@ -412,7 +404,7 @@
             test("should start empty play until done timer on invalid files list", () => {
               element.setAttribute( "play-until-done", true);
 
-              element.files = "risemedialibrary-abc123/README.md";
+              element.files = ["risemedialibrary-abc123/README.md"];
 
               element._start();
 

--- a/test/unit/rise-image.html
+++ b/test/unit/rise-image.html
@@ -247,7 +247,7 @@
 
             assert.isTrue( element._handleImageStatusUpdated.calledWith({
               filePath: "risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/logo.png",
-              fileUrl: "https://storage.googleapis.com/risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/logo.png",
+              fileUrl: `https://storage.googleapis.com/${encodeURIComponent( "risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/logo.png" )}`,
               status: "current"
             } ));
           } );
@@ -258,19 +258,19 @@
 
             assert.deepEqual( element._handleImageStatusUpdated.args[0][0], {
               filePath: "risemedialibrary-abc123/test1.png",
-              fileUrl: "https://storage.googleapis.com/risemedialibrary-abc123/test1.png",
+              fileUrl: `https://storage.googleapis.com/${encodeURIComponent( "risemedialibrary-abc123/test1.png" )}`,
               status: "current"
             } );
 
             assert.deepEqual( element._handleImageStatusUpdated.args[1][0], {
               filePath: "risemedialibrary-abc123/test2.png",
-              fileUrl: "https://storage.googleapis.com/risemedialibrary-abc123/test2.png",
+              fileUrl: `https://storage.googleapis.com/${encodeURIComponent( "risemedialibrary-abc123/test2.png" )}`,
               status: "current"
             } );
 
             assert.deepEqual( element._handleImageStatusUpdated.args[2][0], {
               filePath: "risemedialibrary-abc123/test3.png",
-              fileUrl: "https://storage.googleapis.com/risemedialibrary-abc123/test3.png",
+              fileUrl: `https://storage.googleapis.com/${encodeURIComponent( "risemedialibrary-abc123/test3.png" )}`,
               status: "current"
             } );
           } );


### PR DESCRIPTION
- `files` is now an Array data type to allow file path values to include any special character, i.e. `|`
- Supports legacy implementation of String `files` value with | separator. Component overrides Polymer _deserialization_ for its properties to ensure to convert a String value for `files` to an Array
- Fixed broken Preview URLs for special characters by ensuring to encode the values
- These changes correspond with changes in Apps in order to fix issue https://github.com/Rise-Vision/rise-vision-apps/issues/1063 

Validated with a staged version of the component in _example-financial-template_ and without changing the templates legacy implementation of `files`. Also this is along with the staged Apps changes - https://apps-stage-8.risevision.com/templates/edit/e7cb43cf-b45f-49ba-818e-59fbc445c4d2/?cid=b428b4e8-c8b9-41d5-8a10-b4193c789443