### PR TITLE
Change to use package.json version value as component version value

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,7 @@ jobs:
       - restore_cache:
           key: node-cache-{{ checksum "package.json" }}
       - run: |
-          VERSION=$(cat version-string/version)
+          VERSION=$(grep version package.json | grep -o '[0-9.]*')
           sed -i "
             s/__VERSION__/$VERSION/;
           " src/rise-image-version.js

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-image",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Web component built for Templates to display an image from Storage",
   "repository": "https://github.com/Rise-vision/rise-image.git",
   "bugs": {


### PR DESCRIPTION
## Description
Use the package.json version as the value of component version for logging to BQ. Moving forward, we will consistently bump package.json versions upon every code release. 

## Motivation and Context
When releasing component changes, the current date/timestamp value logged to BQ doesn't provide much insight in knowing what codebase the component is that is running on a display (requires finding CCI build). By ensuring we always bump _package.json_ version and log this to BQ, we can know immediately looking at logs what version of the component is running on the display.

## How Has This Been Tested?
This was tested on ChrOS Player with Charles mapping to remote staged version of component. Logs were analyzed and validated that correct value is being logged - https://www.screencast.com/t/F9VcXxkO9A1.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
  - Manually tested
  - When released, logs will be reviewed for a period of time to confirm success. No code changes that could impact users, very low risk.
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
- No automated tests necessary as there are no code changes that could impact users
- No rollback plan required as there are no code changes that could impact users
- No documentation required
- Support does not need to be aware due to no impact to users
