### PR TITLE
Convert files attribute to Array and support backwards compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ There is no need to configure listeners if the component runs as editable ( defa
     <div id="image-sample-container">
       <rise-image
         id="rise-image-sample"
-        files="risemedialibrary-abc123/file1.png|risemedialibrary-abc123/file2.png|risemedialibrary-abc123/file3.png"
+        files='["risemedialibrary-abc123/file1.png", "risemedialibrary-abc123/file2.png", "risemedialibrary-abc123/file3.png"]'
         duration="5"
         responsive>
       </rise-image>
@@ -39,7 +39,7 @@ This attribute holds a literal value, for example:
 ```
   <rise-image id="rise-image-sample"
     label="Sample"
-    files="risemedialibrary-abc123/logo.png">
+    files='["risemedialibrary-abc123/logo.png"]'>
   </rise-image>
 ```
 
@@ -51,7 +51,7 @@ This component receives the following list of attributes:
 
 - **id**: ( string / required ): Unique HTML id with format 'rise-image-<NAME_OR_NUMBER>'.
 - **label**: ( string ): An optional label key for the text that will appear in the template editor. See 'Labels' section above.
-- **files** ( string / required ): List of image file paths separated by pipe symbol. A file path must be a valid GCS file path. A folder path will not be valid. For example, this is a default folder path from Rise Storage:
+- **files** ( array / required ): List of image file paths applied in JSON format (see [Polymer documentation](https://polymer-library.polymer-project.org/3.0/docs/devguide/properties#configuring-object-and-array-properties) for configuring Array properties). A file path must be a valid GCS file path. A folder path will not be valid. For example, this is a default folder path from Rise Storage:
 https://storage.googleapis.com/risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f/Template%20Library/Global%20Assets/logo-white.png.
 To create a valid GCS path, remove *https://storage.googleapis.com/* and replace *%20* with a space.
 The resulting GCS path is: risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f/Template Library/Global Assets/logo-white.png.

--- a/demo/src/rise-image.html
+++ b/demo/src/rise-image.html
@@ -76,7 +76,7 @@
       id="rise-image-01"
       label="My Image"
       responsive
-      files="risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f/rise-image-demo/Costa Rican Frog.jpg">
+      files='["risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f/rise-image-demo/Costa Rican Frog.jpg"]'>
     </rise-image>
   </div>
 
@@ -88,7 +88,7 @@
       width="300"
       height="200"
       sizing="contain"
-      files="risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f/rise-image-demo/PokemonGO-Team-Logos-Instinct.svg">
+      files='["risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f/rise-image-demo/PokemonGO-Team-Logos-Instinct.svg"]'>
     </rise-image>
   </div>
 
@@ -99,7 +99,7 @@
       label="My Image"
       duration="5"
       responsive
-      files="risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f/rise-image-demo/Pensive Parakeet.jpg|risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f/rise-image-demo/Boston City Flow.jpg|risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f/rise-image-demo/canadiens_logo.gif|risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f/rise-image-demo/blue-jays-logo.jpg|risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f/rise-image-demo/raptors_logo.png">
+      files='["risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f/rise-image-demo/Pensive Parakeet.jpg", "risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f/rise-image-demo/Boston City Flow.jpg", "risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f/rise-image-demo/canadiens_logo.gif", "risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f/rise-image-demo/blue-jays-logo.jpg", "risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f/rise-image-demo/raptors_logo.png"]'>
     </rise-image>
   </div>
 
@@ -112,7 +112,7 @@
       height="200"
       sizing="contain"
       position="top right"
-      files="risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f/rise-image-demo/kcu_logo.png">
+      files='["risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f/rise-image-demo/kcu_logo.png"]'>
     </rise-image>
   </div>
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-image",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Web component built for Templates to display an image from Storage",
   "repository": "https://github.com/Rise-vision/rise-image.git",
   "bugs": {

--- a/src/rise-image.js
+++ b/src/rise-image.js
@@ -258,8 +258,9 @@ class RiseImage extends RiseElement {
       return false;
     }
 
+    // account for existing attribute data overriding files value (with String datatype value) **after** deserialization occurred
     if ( typeof this.files === "string" ) {
-      // account for existing attribute data overriding files value (with String datatype value) **after** deserialization occurred
+      // set flag for _reset() handler to check in order to prevent executing reset operations from observing the below 'files' value change
       this._avoidResetFromFilesConversion = true;
       this.files = this._convertFilesStringToArray( this.files );
     }

--- a/src/rise-image.js
+++ b/src/rise-image.js
@@ -108,6 +108,7 @@ class RiseImage extends RiseElement {
     this._filesToRenderList = [];
     this._transitionIndex = 0;
     this._transitionTimer = null;
+    this._avoidResetFromFilesConversion = false;
   }
 
   ready() {
@@ -179,6 +180,10 @@ class RiseImage extends RiseElement {
   _reset() {
     console.log( "_reset", this._initialStart );
     if ( !this._initialStart ) {
+      if ( this._avoidResetFromFilesConversion ) {
+        this._avoidResetFromFilesConversion = false;
+        return;
+      }
 
       this._stop();
 
@@ -250,13 +255,19 @@ class RiseImage extends RiseElement {
     return files.split( "|" );
   }
 
-  _isValidFiles( files ) {
-    console.log( "_isValidFiles", files );
-    if ( !files || !Array.isArray( files )) {
+  _isValidFiles() {
+    console.log( "_isValidFiles", this.files );
+    if ( !this.files ) {
       return false;
     }
 
-    return files.length > 0 && files.indexOf( "" ) === -1;
+    if ( typeof this.files === "string" ) {
+      // account for existing attribute data overriding files value (with String datatype value) **after** deserialization occurred
+      this._avoidResetFromFilesConversion = true;
+      this.files = this._convertFilesStringToArray( this.files );
+    }
+
+    return this.files.length > 0 && this.files.indexOf( "" ) === -1;
   }
 
   _filterInvalidFileTypes( files ) {
@@ -418,7 +429,7 @@ class RiseImage extends RiseElement {
   }
 
   _start() {
-    if ( !this._isValidFiles( this.files )) {
+    if ( !this._isValidFiles()) {
       return this._startEmptyPlayUntilDoneTimer();
     }
 

--- a/src/rise-image.js
+++ b/src/rise-image.js
@@ -178,7 +178,6 @@ class RiseImage extends RiseElement {
   }
 
   _reset() {
-    console.log( "_reset", this._initialStart );
     if ( !this._initialStart ) {
       if ( this._avoidResetFromFilesConversion ) {
         this._avoidResetFromFilesConversion = false;
@@ -246,7 +245,6 @@ class RiseImage extends RiseElement {
   }
 
   _convertFilesStringToArray( files ) {
-    console.log( "_convertFilesStringToArray", files );
     // single file
     if ( files.indexOf( "|" ) === -1 ) {
       return [ files ];
@@ -256,7 +254,6 @@ class RiseImage extends RiseElement {
   }
 
   _isValidFiles() {
-    console.log( "_isValidFiles", this.files );
     if ( !this.files ) {
       return false;
     }
@@ -353,7 +350,6 @@ class RiseImage extends RiseElement {
   }
 
   _startEmptyPlayUntilDoneTimer() {
-    console.log( "_startEmptyPlayUntilDoneTimer" );
     if ( this.hasAttribute( "play-until-done" )) {
       const duration = parseInt( this.duration, 10 ) || 10;
 

--- a/src/rise-image.js
+++ b/src/rise-image.js
@@ -240,6 +240,7 @@ class RiseImage extends RiseElement {
   }
 
   _convertFilesStringToArray( files ) {
+    console.log( "_convertFilesStringToArray", files );
     // single file
     if ( files.indexOf( "|" ) === -1 ) {
       return [ files ];
@@ -249,6 +250,7 @@ class RiseImage extends RiseElement {
   }
 
   _isValidFiles( files ) {
+    console.log( "_isValidFiles", files );
     if ( !files || !Array.isArray( files )) {
       return false;
     }
@@ -339,6 +341,7 @@ class RiseImage extends RiseElement {
   }
 
   _startEmptyPlayUntilDoneTimer() {
+    console.log( "_startEmptyPlayUntilDoneTimer" );
     if ( this.hasAttribute( "play-until-done" )) {
       const duration = parseInt( this.duration, 10 ) || 10;
 

--- a/src/rise-image.js
+++ b/src/rise-image.js
@@ -23,8 +23,10 @@ class RiseImage extends RiseElement {
   static get properties() {
     return {
       files: {
-        type: String,
-        value: ""
+        type: Array,
+        value: () => {
+          return [];
+        }
       },
       metadata: {
         type: Array,
@@ -114,6 +116,14 @@ class RiseImage extends RiseElement {
 
     this.addEventListener( "rise-presentation-play", () => this._reset());
     this.addEventListener( "rise-presentation-stop", () => this._stop());
+  }
+
+  _deserializeValue( value, type ) {
+    if ( type === Array && value.charAt( 0 ) !== "[" && value.charAt( value.length - 1 ) !== "]" ) {
+      return this._convertFilesStringToArray( value );
+    } else {
+      return super._deserializeValue( value, type );
+    }
   }
 
   _configureImageEventListeners() {
@@ -229,17 +239,21 @@ class RiseImage extends RiseElement {
     });
   }
 
+  _convertFilesStringToArray( files ) {
+    // single file
+    if ( files.indexOf( "|" ) === -1 ) {
+      return [ files ];
+    }
+
+    return files.split( "|" );
+  }
+
   _isValidFiles( files ) {
-    if ( !files || typeof files !== "string" ) {
+    if ( !files || !Array.isArray( files )) {
       return false;
     }
 
-    // single symbol
-    if ( files.indexOf( "|" ) === -1 ) {
-      return true;
-    }
-
-    return files.split( "|" ).indexOf( "" ) === -1;
+    return files.length > 0 && files.indexOf( "" ) === -1;
   }
 
   _filterInvalidFileTypes( files ) {
@@ -404,7 +418,7 @@ class RiseImage extends RiseElement {
       return this._startEmptyPlayUntilDoneTimer();
     }
 
-    this._filesList = this._filterInvalidFileTypes( this.files.split( "|" ));
+    this._filesList = this._filterInvalidFileTypes( this.files );
 
     if ( !this._filesList || !this._filesList.length || this._filesList.length === 0 ) {
       return this._startEmptyPlayUntilDoneTimer();
@@ -454,7 +468,7 @@ class RiseImage extends RiseElement {
   _handleStartForPreview() {
     this._filesList.forEach( file => this._handleImageStatusUpdated({
       filePath: file,
-      fileUrl: RiseImage.STORAGE_PREFIX + file,
+      fileUrl: RiseImage.STORAGE_PREFIX + encodeURIComponent( file ),
       status: this._previewStatusFor( file )
     }));
   }

--- a/src/rise-image.js
+++ b/src/rise-image.js
@@ -177,6 +177,7 @@ class RiseImage extends RiseElement {
   }
 
   _reset() {
+    console.log( "_reset", this._initialStart );
     if ( !this._initialStart ) {
 
       this._stop();

--- a/test/integration/rise-image-logging.html
+++ b/test/integration/rise-image-logging.html
@@ -31,7 +31,7 @@
           height="240"
           sizing="contain"
           position="top"
-          files="risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/logo.png">
+          files='["risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/logo.png"]'>
         </rise-image>
     </template>
 </test-fixture>
@@ -77,7 +77,7 @@
 
       assert.deepEqual( RisePlayerConfiguration.Logger.info.args[ 0 ][ 0 ], componentData );
       assert.equal( RisePlayerConfiguration.Logger.info.args[ 0 ][ 1 ], "start");
-      assert.deepEqual( RisePlayerConfiguration.Logger.info.args[ 0 ][ 2 ], { files: SAMPLE_PATH } );
+      assert.deepEqual( RisePlayerConfiguration.Logger.info.args[ 0 ][ 2 ], { files: [SAMPLE_PATH] } );
     });
 
     test( "should log an 'image-rls-error' event when FILE-ERROR is received", () => {
@@ -107,7 +107,7 @@
     });
 
     test( "should log an 'image-format-invalid' event when file type is invalid", () => {
-        element.files = "risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/test.txt";
+        element.files = ["risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/test.txt"];
 
         element.dispatchEvent( new CustomEvent( "start" ));
 
@@ -130,11 +130,11 @@
         element.dispatchEvent( new CustomEvent( "start" ));
 
         sinon.stub( element, "_start" );
-        element.files = "risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/logo2.png";
+        element.files = ["risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/logo2.png"];
 
         assert.deepEqual( RisePlayerConfiguration.Logger.info.args[ 1 ][ 0 ], componentData );
         assert.equal( RisePlayerConfiguration.Logger.info.args[ 1 ][ 1 ], "image-reset");
-        assert.deepEqual( RisePlayerConfiguration.Logger.info.args[ 1 ][ 2 ], { files: "risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/logo2.png" } );
+        assert.deepEqual( RisePlayerConfiguration.Logger.info.args[ 1 ][ 2 ], { files: ["risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/logo2.png"] } );
 
         element._start.restore();
     } );
@@ -148,7 +148,7 @@
             }
         };
 
-        element.files = filePath;
+        element.files = [filePath];
         element.dispatchEvent( new CustomEvent( "start" ));
 
           setTimeout(() => {
@@ -182,7 +182,7 @@
             }
         };
 
-        element.files = "risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f/rise-image-demo/PokemonGO-Team-Logos-Instinct.svg";
+        element.files = ["risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f/rise-image-demo/PokemonGO-Team-Logos-Instinct.svg"];
         element.dispatchEvent( new CustomEvent( "start" ));
 
         setTimeout( () => {

--- a/test/integration/rise-image-multiple.html
+++ b/test/integration/rise-image-multiple.html
@@ -40,7 +40,7 @@
     <rise-image
       duration="5"
       responsive
-      files="risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f/rise-image-demo/canadiens_logo.gif|risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f/rise-image-demo/blue-jays-logo.jpg|risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f/rise-image-demo/raptors_logo.png">
+      files='["risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f/rise-image-demo/canadiens_logo.gif","risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f/rise-image-demo/blue-jays-logo.jpg","risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f/rise-image-demo/raptors_logo.png"]'>
     </rise-image>
   </template>
 </test-fixture>
@@ -336,21 +336,21 @@
       test('it should render first image', () => {
         element.dispatchEvent( new CustomEvent( "start" ) );
 
-        assert.equal(element.$.image.src, testFiles[ 0 ].url);
+        assert.equal(element.$.image.src, `https://storage.googleapis.com/${ encodeURIComponent( testFiles[ 0 ].path )}`);
       });
 
       test('it should start transition timer for two images and show each for 5 seconds', () => {
         element.dispatchEvent( new CustomEvent( "start" ) );
 
-        assert.equal(element.$.image.src, testFiles[ 0 ].url);
+        assert.equal(element.$.image.src, `https://storage.googleapis.com/${ encodeURIComponent( testFiles[ 0 ].path )}`);
 
         clock.tick( 5000 );
 
-        assert.equal(element.$.image.src, testFiles[ 1 ].url);
+        assert.equal(element.$.image.src, `https://storage.googleapis.com/${ encodeURIComponent( testFiles[ 1 ].path )}`);
 
         clock.tick( 5000 );
 
-        assert.equal(element.$.image.src, testFiles[ 2 ].url);
+        assert.equal(element.$.image.src, `https://storage.googleapis.com/${ encodeURIComponent( testFiles[ 2 ].path )}`);
       });
 
       test('it should transition all three images', () => {
@@ -359,11 +359,11 @@
         // emulate first two images cycle and first two images shown again in the following cycle
         clock.tick( 20000 );
 
-        assert.equal(element.$.image.src, testFiles[ 1 ].url);
+        assert.equal(element.$.image.src, `https://storage.googleapis.com/${ encodeURIComponent( testFiles[ 1 ].path )}`);
 
         clock.tick( 5000 );
 
-        assert.equal(element.$.image.src, testFiles[ 2 ].url);
+        assert.equal(element.$.image.src, `https://storage.googleapis.com/${ encodeURIComponent( testFiles[ 2 ].path )}`);
       });
 
     });

--- a/test/integration/rise-image-single.html
+++ b/test/integration/rise-image-single.html
@@ -30,7 +30,7 @@
       height="240"
       sizing="contain"
       position="top"
-      files="risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/logo.png">
+      files='["risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/logo.png"]'>
     </rise-image>
   </template>
 </test-fixture>
@@ -88,7 +88,7 @@
       test('it should not render image when file type is invalid', () => {
         let spy = sinon.spy( element, "_renderImage" );
 
-        element.files = "risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/test.txt";
+        element.files = ["risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/test.txt"];
 
         element.dispatchEvent( new CustomEvent( "start" ) );
 
@@ -139,7 +139,7 @@
           done();
         });
 
-        element.files = "risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/test.txt";
+        element.files = ["risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/test.txt"];
 
         element.dispatchEvent( new CustomEvent( "start" ) );
       });
@@ -167,7 +167,7 @@
           }
         };
 
-        element.files = svgFilePath;
+        element.files = [svgFilePath];
 
         element.dispatchEvent( new CustomEvent( "start" ) );
       })
@@ -185,7 +185,7 @@
       test('it should render image', () => {
         element.dispatchEvent( new CustomEvent( "start" ) );
 
-        assert.equal(element.$.image.src, SAMPLE_URL);
+        assert.equal(element.$.image.src, `https://storage.googleapis.com/${ encodeURIComponent( SAMPLE_PATH )}`);
       });
 
     });

--- a/test/unit/rise-image.html
+++ b/test/unit/rise-image.html
@@ -30,7 +30,7 @@
           height="240"
           sizing="contain"
           position="top"
-          files="risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/logo.png">
+          files='["risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/logo.png"]'>
         </rise-image>
       </template>
     </test-fixture>
@@ -50,26 +50,19 @@
         });
 
         suite( "_isValidFiles", () => {
-          test( "should return true if 'files' attribute is a non-empty String", () => {
-            assert.isTrue( element._isValidFiles( "test" ) );
+          test( "should return true if 'files' attribute is not empty", () => {
+            assert.isTrue( element._isValidFiles( ["test1.jpg", "test2.jpg"] ) );
           } );
 
-          test( "should return false if 'files' attribute is not a String or empty String", () => {
-            assert.isFalse( element._isValidFiles( 123 ) );
-            assert.isFalse( element._isValidFiles( ["test1|test2"] ) );
+          test( "should return false if 'files' attribute is empty or is an empty Array", () => {
+            assert.isFalse( element._isValidFiles( [] ) );
             assert.isFalse( element._isValidFiles( "" ) );
           } );
 
-          test( "should return true if 'files' attribute is a String containing values separated by '|'", () => {
-            assert.isTrue( element._isValidFiles( "test1|test2|test3" ) );
+          test( "should return false if 'files' attribute contains an item with an empty value", () => {
+            assert.isFalse( element._isValidFiles( ["test1.jpg","", "test2.jpg"] ) );
           } );
 
-          test( "should return false if 'files' attribute contains '|' with any empty value", () => {
-            assert.isFalse(element._isValidFiles("test|"));
-            assert.isFalse(element._isValidFiles("|test"));
-            assert.isFalse(element._isValidFiles("|"));
-            assert.isFalse(element._isValidFiles("test1|test2||test3"));
-          } );
         } );
 
         suite( "_getStorageFileFormat", () => {
@@ -255,7 +248,7 @@
 
             assert.isTrue( element._handleImageStatusUpdated.calledWith({
               filePath: "risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/logo.png",
-              fileUrl: "https://storage.googleapis.com/risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/logo.png",
+              fileUrl: `https://storage.googleapis.com/${encodeURIComponent( "risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/logo.png" )}`,
               status: "current"
             } ));
           } );
@@ -266,19 +259,19 @@
 
             assert.deepEqual( element._handleImageStatusUpdated.args[0][0], {
               filePath: "risemedialibrary-abc123/test1.png",
-              fileUrl: "https://storage.googleapis.com/risemedialibrary-abc123/test1.png",
+              fileUrl: `https://storage.googleapis.com/${encodeURIComponent( "risemedialibrary-abc123/test1.png" )}`,
               status: "current"
             } );
 
             assert.deepEqual( element._handleImageStatusUpdated.args[1][0], {
               filePath: "risemedialibrary-abc123/test2.png",
-              fileUrl: "https://storage.googleapis.com/risemedialibrary-abc123/test2.png",
+              fileUrl: `https://storage.googleapis.com/${encodeURIComponent( "risemedialibrary-abc123/test2.png" )}`,
               status: "current"
             } );
 
             assert.deepEqual( element._handleImageStatusUpdated.args[2][0], {
               filePath: "risemedialibrary-abc123/test3.png",
-              fileUrl: "https://storage.googleapis.com/risemedialibrary-abc123/test3.png",
+              fileUrl: `https://storage.googleapis.com/${encodeURIComponent( "risemedialibrary-abc123/test3.png" )}`,
               status: "current"
             } );
           } );
@@ -412,7 +405,7 @@
             test("should start empty play until done timer on invalid files list", () => {
               element.setAttribute( "play-until-done", true);
 
-              element.files = "risemedialibrary-abc123/README.md";
+              element.files = ["risemedialibrary-abc123/README.md"];
 
               element._start();
 

--- a/test/unit/rise-image.html
+++ b/test/unit/rise-image.html
@@ -51,16 +51,19 @@
 
         suite( "_isValidFiles", () => {
           test( "should return true if 'files' attribute is not empty", () => {
-            assert.isTrue( element._isValidFiles( ["test1.jpg", "test2.jpg"] ) );
+            assert.isTrue( element._isValidFiles() );
           } );
 
           test( "should return false if 'files' attribute is empty or is an empty Array", () => {
-            assert.isFalse( element._isValidFiles( [] ) );
-            assert.isFalse( element._isValidFiles( "" ) );
+            element.files = [];
+            assert.isFalse( element._isValidFiles() );
+            element.files = "";
+            assert.isFalse( element._isValidFiles() );
           } );
 
           test( "should return false if 'files' attribute contains an item with an empty value", () => {
-            assert.isFalse( element._isValidFiles( ["test1.jpg","", "test2.jpg"] ) );
+            element.files= ["test1.jpg","", "test2.jpg"];
+            assert.isFalse( element._isValidFiles() );
           } );
 
         } );

--- a/test/unit/rise-image.html
+++ b/test/unit/rise-image.html
@@ -66,6 +66,12 @@
             assert.isFalse( element._isValidFiles() );
           } );
 
+          test( "should return true if 'files' was overwritten to be of String data type", () => {
+            element.files= "test1.jpg|test2.jpg|test3.jpg";
+            assert.isTrue( element._isValidFiles() );
+            assert.deepEqual( element.files, ["test1.jpg", "test2.jpg", "test3.jpg"] );
+          } );
+
         } );
 
         suite( "_getStorageFileFormat", () => {
@@ -186,6 +192,21 @@
             assert.equal( element._transitionIndex, 0 );
             assert.isTrue( element._clearDisplayedImage.called );
             assert.isTrue( element._start.calledOnce );
+          } );
+
+          test( "should not execute any reset operations if '_avoidResetFromFilesConversion' flag set", () => {
+            sinon.spy( element, "_stop" );
+
+            element._initialStart = false;
+            element._watchInitiated = true;
+            element._filesList = [ SAMPLE_PATH ];
+
+            element._avoidResetFromFilesConversion = true;
+            element._reset();
+
+            element._filesList = [ SAMPLE_PATH ];
+            assert.isTrue( element._stop.notCalled );
+            assert.isTrue( element._start.notCalled );
           } );
 
         } );


### PR DESCRIPTION
## Description
Converting the `files` attribute to Array data type to allow for supporting all special characters in Storage file and folder names, including the `|` character. 

## Motivation and Context
This change is required as a part of the overall fix for issue https://github.com/Rise-Vision/rise-vision-apps/issues/1063 . The `files` attribute has up to now been String value with | separated GCS file path values. If a file name or folder name had a | in the name, then the component incorrectly parsed the value to obtain each file path. Our users should be able to use any special character in a file or folder name, so `files` should be an Array data type to support this. 

## How Has This Been Tested?
Testing has been done with a staged version of the component. The changes to the component have been written to be backwards compatible in regards to the configuration of `files` value. 

Scenarios that have been tested and validated:
- Staged component running in Editor Preview on Apps staging mirroring production code
- Staged component running in Editor Preview on Apps staging that contains the Template Editor changes for implementing the other part of the fix. 
- Staged component running on ChrOS display from RV test company, with attribute data saved from Apps staging mirroring production code
- Staged component running on ChrOS display from RV test company, with attribute data saved from Apps staging that contains the Template Editor changes for implementing the other part of the fix. 

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed.
  - Manually tested on staging
  - Includes revised and additional automated tests 
  - Upon release, will be validating no issue on Production. Will be monitoring rise-image logs and uptime, as well as monitor the amount of displays using latest version on a daily basis until all displays using rise-image are using latest version, which is necessary for releasing the Apps changes. Query to be used [here](https://github.com/Rise-Vision/bigquery-queries/blob/master/projects/client-side-events/datasets/Display_Events/ComponentVersionStats.bq)
  - Rollback will involve re-running previous stable deployment followed by reverting code changes and merging to master branch
  - Documentation has been included in the changes to the README 
  - Upon release, will notify Support
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
Nothing skipped
