### PR TITLE
Fix/issue 29 image refresh in preview

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-image",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Web component built for Templates to display an image from Storage",
   "repository": "https://github.com/Rise-vision/rise-image.git",
   "bugs": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-image",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Web component built for Templates to display an image from Storage",
   "repository": "https://github.com/Rise-vision/rise-image.git",
   "bugs": {

--- a/src/rise-image.js
+++ b/src/rise-image.js
@@ -438,23 +438,44 @@ class RiseImage extends RiseElement {
     this._transitionIndex = 0;
   }
 
-  _previewStatusFor( file ) {
+  _hasMetadata() {
     // Metadata may not be present if no data updates have been received yet.
-    const hasMetadata = this.metadata && this.metadata.length > 0;
+    return this.metadata && this.metadata.length > 0;
+  }
+
+  _metadataEntryFor( file ) {
+    return this.metadata.find( current => current.file === file );
+  }
+
+  _previewStatusFor( file ) {
+    const hasMetadata = this._hasMetadata();
 
     if ( !hasMetadata ) {
       return "current";
     }
 
-    const entry = this.metadata.find( current => current.file === file );
+    const entry = this._metadataEntryFor( file );
 
     return entry && entry.exists ? "current" : "deleted";
+  }
+
+  _timeCreatedFor( file ) {
+    const hasMetadata = this._hasMetadata();
+
+    if ( !hasMetadata ) {
+      return "";
+    }
+
+    const entry = this._metadataEntryFor( file );
+
+    return entry && entry[ "time-created" ] ? entry[ "time-created" ] : "";
   }
 
   _handleStartForPreview() {
     this._filesList.forEach( file => this._handleImageStatusUpdated({
       filePath: file,
-      fileUrl: RiseImage.STORAGE_PREFIX + file,
+      fileUrl: RiseImage.STORAGE_PREFIX + file + "?_=" +
+        this._timeCreatedFor( file ),
       status: this._previewStatusFor( file )
     }));
   }

--- a/test/integration/rise-image-multiple.html
+++ b/test/integration/rise-image-multiple.html
@@ -336,21 +336,21 @@
       test('it should render first image', () => {
         element.dispatchEvent( new CustomEvent( "start" ) );
 
-        assert.equal(element.$.image.src, testFiles[ 0 ].url);
+        assert.equal(element.$.image.src, testFiles[ 0 ].url + "?_=");
       });
 
       test('it should start transition timer for two images and show each for 5 seconds', () => {
         element.dispatchEvent( new CustomEvent( "start" ) );
 
-        assert.equal(element.$.image.src, testFiles[ 0 ].url);
+        assert.equal(element.$.image.src, testFiles[ 0 ].url + "?_=");
 
         clock.tick( 5000 );
 
-        assert.equal(element.$.image.src, testFiles[ 1 ].url);
+        assert.equal(element.$.image.src, testFiles[ 1 ].url + "?_=");
 
         clock.tick( 5000 );
 
-        assert.equal(element.$.image.src, testFiles[ 2 ].url);
+        assert.equal(element.$.image.src, testFiles[ 2 ].url + "?_=");
       });
 
       test('it should transition all three images', () => {
@@ -359,11 +359,11 @@
         // emulate first two images cycle and first two images shown again in the following cycle
         clock.tick( 20000 );
 
-        assert.equal(element.$.image.src, testFiles[ 1 ].url);
+        assert.equal(element.$.image.src, testFiles[ 1 ].url + "?_=");
 
         clock.tick( 5000 );
 
-        assert.equal(element.$.image.src, testFiles[ 2 ].url);
+        assert.equal(element.$.image.src, testFiles[ 2 ].url + "?_=");
       });
 
     });

--- a/test/integration/rise-image-single.html
+++ b/test/integration/rise-image-single.html
@@ -182,10 +182,10 @@
         RisePlayerConfiguration.isPreview = () => false;
       });
 
-      test('it should render image', () => {
+      test('it should render image with a cache bumper parameter', () => {
         element.dispatchEvent( new CustomEvent( "start" ) );
 
-        assert.equal(element.$.image.src, SAMPLE_URL);
+        assert.equal(element.$.image.src, SAMPLE_URL + "?_=");
       });
 
     });

--- a/test/unit/rise-image.html
+++ b/test/unit/rise-image.html
@@ -255,7 +255,7 @@
 
             assert.isTrue( element._handleImageStatusUpdated.calledWith({
               filePath: "risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/logo.png",
-              fileUrl: "https://storage.googleapis.com/risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/logo.png",
+              fileUrl: "https://storage.googleapis.com/risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/logo.png?_=",
               status: "current"
             } ));
           } );
@@ -266,19 +266,19 @@
 
             assert.deepEqual( element._handleImageStatusUpdated.args[0][0], {
               filePath: "risemedialibrary-abc123/test1.png",
-              fileUrl: "https://storage.googleapis.com/risemedialibrary-abc123/test1.png",
+              fileUrl: "https://storage.googleapis.com/risemedialibrary-abc123/test1.png?_=",
               status: "current"
             } );
 
             assert.deepEqual( element._handleImageStatusUpdated.args[1][0], {
               filePath: "risemedialibrary-abc123/test2.png",
-              fileUrl: "https://storage.googleapis.com/risemedialibrary-abc123/test2.png",
+              fileUrl: "https://storage.googleapis.com/risemedialibrary-abc123/test2.png?_=",
               status: "current"
             } );
 
             assert.deepEqual( element._handleImageStatusUpdated.args[2][0], {
               filePath: "risemedialibrary-abc123/test3.png",
-              fileUrl: "https://storage.googleapis.com/risemedialibrary-abc123/test3.png",
+              fileUrl: "https://storage.googleapis.com/risemedialibrary-abc123/test3.png?_=",
               status: "current"
             } );
           } );

--- a/test/unit/rise-image.html
+++ b/test/unit/rise-image.html
@@ -246,6 +246,8 @@
           });
 
           teardown( () => {
+            element.metadata = null;
+
             element._handleImageStatusUpdated.restore();
           } );
 
@@ -282,6 +284,22 @@
               status: "current"
             } );
           } );
+
+          test( "should call _handleImageStatusUpdated with correct data and time created", () => {
+            const file = "risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/logo.png";
+            element._filesList = [ file ];
+            element.metadata = [
+              { file, exists: true, "time-created": 123 }
+            ];
+            element._handleStartForPreview();
+
+            assert.isTrue( element._handleImageStatusUpdated.calledWith({
+              filePath: "risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/logo.png",
+              fileUrl: "https://storage.googleapis.com/risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/logo.png?_=123",
+              status: "current"
+            } ));
+          } );
+
         } );
 
        suite( "uptime", () => {
@@ -336,7 +354,7 @@
 
         });
 
-        suite( "Play Unitl Done", () => {
+        suite( "Play Until Done", () => {
 
           suite( "_isDone()", () => {
 


### PR DESCRIPTION
## Description
Preview mode now includes a time created variable to the image request, so the image refreshes even if it's replaced ( currently the browser cache prevents this refresh ). 

https://github.com/Rise-Vision/rise-image/issues/29

## Motivation and Context
Copied from card: Related to the thumbnails issue update that was fixed as part of Rise-Vision/rise-vision-apps: Issue #1061, we should add an extra parameter to the image URL that references GCS' timeCreated.value. This is only needed for Preview, since RLS handles this correctly for the displays.

The following branch 
https://github.com/Rise-Vision/rise-vision-apps/compare/fix/issue-29-image-refresh-in-preview?expand=1
implements the Apps part of the fix. 

## How Has This Been Tested?
A template for the staged template was created and loaded in this presentation:
https://apps-stage-9.risevision.com/templates/edit/46841dc1-efef-4a2d-84c9-1e0a14932ff4/?cid=cf85e5c4-9439-40ce-94d6-e5ea6ea2411c

If the image is replaced with one with the same name, preview will update with the new file. ( this test also uses the editor code in [this Apps branch](https://github.com/Rise-Vision/rise-vision-apps/compare/fix/issue-29-image-refresh-in-preview?expand=1) ), as the update won't happen unless rise-image receives the time-created value as part of the images metadata.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
     - the component can be safely released even if Apps changes have not been merged, it just will behave as previously when it does not receive the time-created entry.
     - manual and automated tests performed
     - not release on Friday, developers available
     - will monitor on production right after releasing to validate it isn't causing problems
     - can be rolled back easily, but presentations that may have loaded this version of the component may need to be restarted from Apps. that's why validation will be performed as soon as possible.

- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
      no update to support is necessary
