### PR TITLE
Use metadata to construct files list and fallback on files attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-image",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Web component built for Templates to display an image from Storage",
   "repository": "https://github.com/Rise-vision/rise-image.git",
   "bugs": {

--- a/src/rise-image.js
+++ b/src/rise-image.js
@@ -28,7 +28,7 @@ class RiseImage extends RiseElement {
       },
       metadata: {
         type: Array,
-        value: []
+        value: null
       },
       width: {
         type: String,
@@ -166,12 +166,19 @@ class RiseImage extends RiseElement {
     return this._filesToRenderList.find( file => file.filePath === filePath );
   }
 
+  _getFilesFromMetadata() {
+    return !this.metadata ? [] : this.metadata.map(( entry ) => {
+      return entry.file;
+    });
+  }
+
+  _hasMetadata() {
+    return !!this.metadata && this.metadata.length > 0;
+  }
+
   _reset() {
     if ( !this._initialStart ) {
-      const hasMetadata = this.metadata && this.metadata.length > 0;
-      const filesToLog = !hasMetadata ? this.files : this.metadata.map(( entry ) => {
-        return entry.file;
-      });
+      const filesToLog = !this.metadata ? this.files : this._getFilesFromMetadata();
 
       this._stop();
 
@@ -404,19 +411,14 @@ class RiseImage extends RiseElement {
   }
 
   _start() {
-    // Metadata may not be present if no data updates have been received yet.
-    const hasMetadata = this.metadata && this.metadata.length > 0;
-
-    if ( !hasMetadata ) {
+    if ( !this._hasMetadata()) {
       if ( !this._isValidFiles( this.files )) {
         return this._startEmptyPlayUntilDoneTimer();
       }
 
       this._filesList = this._filterInvalidFileTypes( this.files.split( "|" ));
     } else {
-      const filesArray = this.metadata.map(( entry ) => {
-        return entry.file;
-      });
+      const filesArray = this._getFilesFromMetadata();
 
       // validate metadata files
       if ( !filesArray || !filesArray.length || filesArray.length === 0 ) {
@@ -459,10 +461,7 @@ class RiseImage extends RiseElement {
   }
 
   _previewStatusFor( file ) {
-    // Metadata may not be present if no data updates have been received yet.
-    const hasMetadata = this.metadata && this.metadata.length > 0;
-
-    if ( !hasMetadata ) {
+    if ( !this._hasMetadata()) {
       return "current";
     }
 

--- a/src/rise-image.js
+++ b/src/rise-image.js
@@ -233,15 +233,6 @@ class RiseImage extends RiseElement {
     });
   }
 
-  _convertFilesStringToArray( files ) {
-    // single file
-    if ( files.indexOf( "|" ) === -1 ) {
-      return [ files ];
-    }
-
-    return files.split( "|" );
-  }
-
   _isValidFiles( files ) {
     if ( !files || typeof files !== "string" ) {
       return false;

--- a/src/rise-image.js
+++ b/src/rise-image.js
@@ -400,6 +400,13 @@ class RiseImage extends RiseElement {
   }
 
   _start() {
+    // Metadata may not be present if no data updates have been received yet.
+    const hasMetadata = this.metadata && this.metadata.length > 0;
+
+    if ( hasMetadata ) {
+      
+    }
+
     if ( !this._isValidFiles( this.files )) {
       return this._startEmptyPlayUntilDoneTimer();
     }

--- a/src/rise-image.js
+++ b/src/rise-image.js
@@ -427,8 +427,6 @@ class RiseImage extends RiseElement {
         return entry.file;
       });
 
-      console.log( "metadata files array", filesArray );
-
       // validate metadata files
       if ( !filesArray || !filesArray.length || filesArray.length === 0 ) {
         return this._startEmptyPlayUntilDoneTimer();

--- a/test/integration/rise-image-multiple.html
+++ b/test/integration/rise-image-multiple.html
@@ -336,21 +336,21 @@
       test('it should render first image', () => {
         element.dispatchEvent( new CustomEvent( "start" ) );
 
-        assert.equal(element.$.image.src, testFiles[ 0 ].url);
+        assert.equal(element.$.image.src, "https://storage.googleapis.com/risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f%2Frise-image-demo%2Fcanadiens_logo.gif");
       });
 
       test('it should start transition timer for two images and show each for 5 seconds', () => {
         element.dispatchEvent( new CustomEvent( "start" ) );
 
-        assert.equal(element.$.image.src, testFiles[ 0 ].url);
+        assert.equal(element.$.image.src, "https://storage.googleapis.com/risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f%2Frise-image-demo%2Fcanadiens_logo.gif");
 
         clock.tick( 5000 );
 
-        assert.equal(element.$.image.src, testFiles[ 1 ].url);
+        assert.equal(element.$.image.src, "https://storage.googleapis.com/risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f%2Frise-image-demo%2Fblue-jays-logo.jpg");
 
         clock.tick( 5000 );
 
-        assert.equal(element.$.image.src, testFiles[ 2 ].url);
+        assert.equal(element.$.image.src, "https://storage.googleapis.com/risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f%2Frise-image-demo%2Fraptors_logo.png");
       });
 
       test('it should transition all three images', () => {
@@ -359,11 +359,11 @@
         // emulate first two images cycle and first two images shown again in the following cycle
         clock.tick( 20000 );
 
-        assert.equal(element.$.image.src, testFiles[ 1 ].url);
+        assert.equal(element.$.image.src, "https://storage.googleapis.com/risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f%2Frise-image-demo%2Fblue-jays-logo.jpg");
 
         clock.tick( 5000 );
 
-        assert.equal(element.$.image.src, testFiles[ 2 ].url);
+        assert.equal(element.$.image.src, "https://storage.googleapis.com/risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f%2Frise-image-demo%2Fraptors_logo.png");
       });
 
     });

--- a/test/integration/rise-image-single.html
+++ b/test/integration/rise-image-single.html
@@ -185,7 +185,7 @@
       test('it should render image', () => {
         element.dispatchEvent( new CustomEvent( "start" ) );
 
-        assert.equal(element.$.image.src, SAMPLE_URL);
+        assert.equal(element.$.image.src, "https://storage.googleapis.com/risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013%2Flogo.png");
       });
 
     });

--- a/test/unit/rise-image.html
+++ b/test/unit/rise-image.html
@@ -147,6 +147,45 @@
 
         });
 
+        suite( "_getFilesFromMetadata", () => {
+          test( "should handle null metadata value", () => {
+            assert.deepEqual( element._getFilesFromMetadata(), []);
+          } );
+
+          test( "should return correct list of files", () => {
+            element.metadata = [
+              { file: "test1.jpg", "thumbnail-url": "http://test1.jpg", exists: true },
+              { file: "test2.jpg", "thumbnail-url": "http://test2.jpg", exists: true },
+              { file: "test3.jpg", "thumbnail-url": "http://test3.jpg", exists: true }
+            ]
+            assert.deepEqual( element._getFilesFromMetadata(), [
+              "test1.jpg", "test2.jpg", "test3.jpg"
+            ]);
+          } );
+
+          test( "should handle empty metadata value", () => {
+            element.metadata = [];
+            assert.deepEqual( element._getFilesFromMetadata(), []);
+          } );
+        } );
+
+        suite( "_hasMetadata", () => {
+          test( "should return correct value", () => {
+            // null value
+            assert.isFalse( element._hasMetadata());
+
+            element.metadata = [];
+            assert.isFalse( element._hasMetadata() );
+
+            element.metadata = [
+              { file: "test1.jpg", "thumbnail-url": "http://test1.jpg", exists: true },
+              { file: "test2.jpg", "thumbnail-url": "http://test2.jpg", exists: true },
+              { file: "test3.jpg", "thumbnail-url": "http://test3.jpg", exists: true }
+            ];
+            assert.isTrue( element._hasMetadata() );
+          } );
+        } );
+
         suite( "_filterInvalidFileTypes", () => {
           test( "should return filtered files list", () => {
             assert.deepEqual( element._filterInvalidFileTypes( [ "test1.jpg", "test2.gif", "test3.txt", "test4.png", "test5.webm" ] ), [

--- a/test/unit/rise-image.html
+++ b/test/unit/rise-image.html
@@ -255,7 +255,7 @@
 
             assert.isTrue( element._handleImageStatusUpdated.calledWith({
               filePath: "risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/logo.png",
-              fileUrl: "https://storage.googleapis.com/risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/logo.png",
+              fileUrl: "https://storage.googleapis.com/risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013%2Flogo.png",
               status: "current"
             } ));
           } );
@@ -266,19 +266,19 @@
 
             assert.deepEqual( element._handleImageStatusUpdated.args[0][0], {
               filePath: "risemedialibrary-abc123/test1.png",
-              fileUrl: "https://storage.googleapis.com/risemedialibrary-abc123/test1.png",
+              fileUrl: "https://storage.googleapis.com/risemedialibrary-abc123%2Ftest1.png",
               status: "current"
             } );
 
             assert.deepEqual( element._handleImageStatusUpdated.args[1][0], {
               filePath: "risemedialibrary-abc123/test2.png",
-              fileUrl: "https://storage.googleapis.com/risemedialibrary-abc123/test2.png",
+              fileUrl: "https://storage.googleapis.com/risemedialibrary-abc123%2Ftest2.png",
               status: "current"
             } );
 
             assert.deepEqual( element._handleImageStatusUpdated.args[2][0], {
               filePath: "risemedialibrary-abc123/test3.png",
-              fileUrl: "https://storage.googleapis.com/risemedialibrary-abc123/test3.png",
+              fileUrl: "https://storage.googleapis.com/risemedialibrary-abc123%2Ftest3.png",
               status: "current"
             } );
           } );


### PR DESCRIPTION
## Description
Use `metadata` attribute to construct the files list for the component to use and fallback on using `files` attribute which will be the default files applied to the instance

Encoding the preview storage URL to support special characters in the URL

## Motivation and Context
This change is required as a part of the overall fix for issue https://github.com/Rise-Vision/rise-vision-apps/issues/1063 . If a file name or folder name had a | in the name, then the component incorrectly parsed the `files` value to obtain each file path. Our users should be able to use any special character in a file or folder name, so using `metadata` allows the component to correctly construct file list. 

## How Has This Been Tested?
Testing has been done with a staged version of the component running in a test template on Apps staging. 

Scenarios that have been tested and validated:
- Staged component running in Editor Preview on Apps staging mirroring production code
- Staged component running in Editor Preview on Apps staging that contains the Template Editor changes for implementing the other part of the fix. 
- Staged component running on ChrOS display from RV test company, with attribute data saved from Apps staging mirroring production code
- Staged component running on ChrOS display from RV test company, with attribute data saved from Apps staging that contains the Template Editor changes for implementing the other part of the fix. 

https://apps-stage-8.risevision.com/templates/edit/944fde47-490e-48bd-a806-8c22b030d944/?cid=b428b4e8-c8b9-41d5-8a10-b4193c789443

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
  - Manually tested on staging
  - Includes revised automated tests 
  - Upon release, will be validating no issue on Production. Will be monitoring rise-image logs and uptime, as well as monitor the amount of displays using latest version today and observe logs and screenshots of those displays. Latest version query to be used [here](https://github.com/Rise-Vision/bigquery-queries/blob/master/projects/client-side-events/datasets/Display_Events/ComponentVersionStats.bq)
  - Rollback will involve re-running previous stable deployment followed by reverting code changes and merging to master branch 
  - Upon release, will notify Support
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
- No documentation required as there is no change to usage of the component
