### PR TITLE
Keep looping images when done

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-image",
-  "version": "1.0.0",
+  "version": "1.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/rise-image.js
+++ b/src/rise-image.js
@@ -312,7 +312,7 @@ class RiseImage extends RiseElement {
 
   _onShowImageComplete() {
     if ( this._isDone()) {
-      return super._sendDoneEvent( true );
+      super._sendDoneEvent( true );
     }
 
     if ( this._transitionIndex < ( this._filesToRenderList.length - 1 )) {

--- a/test/unit/rise-image.html
+++ b/test/unit/rise-image.html
@@ -443,6 +443,17 @@
               assert.isTrue( element._sendDoneEvent.calledWith(true) );
             });
 
+             test("should keep transitioning the images when it is done", () => {
+              element.setAttribute( "play-until-done", true);
+
+              element._transitionIndex = 0;
+              element._filesToRenderList = [{ filePath: "risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f/DSC01624.JPG"}, { filePath: "risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f/DSC01625.JPG"}];
+
+              element._onShowImageComplete();
+
+              assert.equal( element._transitionIndex, 1);
+            });
+
           });
 
           suite( "_startEmptyPlayUntilDoneTimer()", () => {


### PR DESCRIPTION
## Description
Do not stop image rotation when it is done to keep them looping when PUD template is a single item in the schedule

## Motivation and Context

Fix to defect https://github.com/Rise-Vision/rise-vision-apps/issues/1156

## How Has This Been Tested?
Tested locally with Charles proxy mapping

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed
