### PR TITLE
Feature/implement mixins

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,9 +93,7 @@ The component may log the following:
 - **_image-reset_** ( info ): The component observed changes to either _files_ or _duration_ attributes and performs a complete reset to use latest values.
 - **_image-svg-usage_** ( info ): Provides an SVG file _blob size_ and _data url length_ info for investigative purposes.
 - **_image-load-fail_** ( error ): When attempting to render an available image, the image load failed.
-- **_image-format-invalid_** ( error ): A GCS path was set that targets a file with an invalid image file format. Valid image file formats are: jpg, jpeg, png, bmp, svg, gif, and webp.
 - **_image-svg-fail_** ( error ): When component is targeting an SVG file, the component converts the local file URL to a data url to support running on Electron Player. This error event indicates the attempt to get data url or render the SVG file failed.
-- **_image-rls-error_** ( error ): An error is received from Rise Local Storage for a file
 
 In every case of an error, examine event-details entry and the other event fields for more information about the problem.
 

--- a/README.md
+++ b/README.md
@@ -96,11 +96,11 @@ The component may log the following:
 
 Additionally, because the component inherits from [WatchFilesMixin](https://github.com/Rise-Vision/rise-common-component/blob/master/src/watch-files-mixin.js) and [ValidFilesMixin](https://github.com/Rise-Vision/rise-common-component/blob/master/src/valid-files-mixin.js) in [rise-common-component](https://github.com/Rise-Vision/rise-common-component), it may log the following:
 
-- **_file-not-found_** (error): A watched file is not found
-- **_file-insufficient-disk-space-error_** (error): A watched file can not be downloaded due to a lack of disk space
-- **_file-rls-error_** (error): A general RLS error is encountered for a watched file
-- **_format-invalid_** (error): A file with an invalid extension is encountered
-- **_all-formats-invalid_** (error): All files have invalid formats
+- **_file-not-found_** (error): A watched file is not found.
+- **_file-insufficient-disk-space-error_** (error): A watched file can not be downloaded due to a lack of disk space.
+- **_file-rls-error_** (error): A general RLS error is encountered for a watched file.
+- **_format-invalid_** (error): A file with an invalid extension is encountered.
+- **_all-formats-invalid_** (error): All files have invalid formats.
 
 In every case of an error, examine event-details entry and the other event fields for more information about the problem.
 

--- a/README.md
+++ b/README.md
@@ -67,7 +67,6 @@ The resulting GCS path is: risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f
 - **play-until-done**: ( empty / optional ): If present, it indicates this component will send the `"report-done"` event when if finishes showing the images.
 - **is-logo**: ( boolean / optional ): If ``"true"``, it indicates this component will display the Company Logo defined in the Branding settings.
 
-
 ### Events
 
 The component sends the following events:
@@ -94,6 +93,14 @@ The component may log the following:
 - **_image-svg-usage_** ( info ): Provides an SVG file _blob size_ and _data url length_ info for investigative purposes.
 - **_image-load-fail_** ( error ): When attempting to render an available image, the image load failed.
 - **_image-svg-fail_** ( error ): When component is targeting an SVG file, the component converts the local file URL to a data url to support running on Electron Player. This error event indicates the attempt to get data url or render the SVG file failed.
+
+Additionally, because the component inherits from [WatchFilesMixin](https://github.com/Rise-Vision/rise-common-component/blob/master/src/watch-files-mixin.js) and [ValidFilesMixin](https://github.com/Rise-Vision/rise-common-component/blob/master/src/valid-files-mixin.js) in [rise-common-component](https://github.com/Rise-Vision/rise-common-component), it may log the following:
+
+- **_file-not-found_** (error): A watched file is not found
+- **_file-insufficient-disk-space-error_** (error): A watched file can not be downloaded due to a lack of disk space
+- **_file-rls-error_** (error): A general RLS error is encountered for a watched file
+- **_format-invalid_** (error): A file with an invalid extension is encountered
+- **_all-formats-invalid_** (error): All files have invalid formats
 
 In every case of an error, examine event-details entry and the other event fields for more information about the problem.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1017,7 +1017,7 @@
       }
     },
     "rise-common-component": {
-      "version": "git://github.com/Rise-Vision/rise-common-component.git#6105a97e5d7c3eb8124f4a13ed0af196d94dec87",
+      "version": "git://github.com/Rise-Vision/rise-common-component.git#adcb2dfb136f6575bfe0b1a430d8a064cf10a729",
       "requires": {
         "@polymer/polymer": "3.1.0",
         "@webcomponents/webcomponentsjs": "2.2.10"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1017,7 +1017,7 @@
       }
     },
     "rise-common-component": {
-      "version": "git://github.com/Rise-Vision/rise-common-component.git#e4b08107d0682b13e9e5080e4300f437c51cb65c",
+      "version": "git://github.com/Rise-Vision/rise-common-component.git#0aab85592c0ab84ccf73da59d04271576e7b3035",
       "requires": {
         "@polymer/polymer": "3.1.0",
         "@webcomponents/webcomponentsjs": "2.2.10"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1017,7 +1017,7 @@
       }
     },
     "rise-common-component": {
-      "version": "git://github.com/Rise-Vision/rise-common-component.git#0dd628a1b1353be9b41f01531be08e83e117ea73",
+      "version": "git://github.com/Rise-Vision/rise-common-component.git#6105a97e5d7c3eb8124f4a13ed0af196d94dec87",
       "requires": {
         "@polymer/polymer": "3.1.0",
         "@webcomponents/webcomponentsjs": "2.2.10"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1017,7 +1017,7 @@
       }
     },
     "rise-common-component": {
-      "version": "git://github.com/Rise-Vision/rise-common-component.git#0aab85592c0ab84ccf73da59d04271576e7b3035",
+      "version": "git://github.com/Rise-Vision/rise-common-component.git#0dd628a1b1353be9b41f01531be08e83e117ea73",
       "requires": {
         "@polymer/polymer": "3.1.0",
         "@webcomponents/webcomponentsjs": "2.2.10"

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@polymer/iron-image": "^3.0.1",
     "@polymer/polymer": "3.1.0",
     "@webcomponents/webcomponentsjs": "^2.1.3",
-    "rise-common-component": "git://github.com/Rise-Vision/rise-common-component.git#chore/all-formats-invalid-error"
+    "rise-common-component": "git://github.com/Rise-Vision/rise-common-component.git#v1.0.13"
   },
   "devDependencies": {
     "eslint": "^5.16.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@polymer/iron-image": "^3.0.1",
     "@polymer/polymer": "3.1.0",
     "@webcomponents/webcomponentsjs": "^2.1.3",
-    "rise-common-component": "git://github.com/Rise-Vision/rise-common-component.git#v1.0.6"
+    "rise-common-component": "git://github.com/Rise-Vision/rise-common-component.git#v1.0.12"
   },
   "devDependencies": {
     "eslint": "^5.16.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-image",
-  "version": "1.1.2",
+  "version": "2.0.0",
   "description": "Web component built for Templates to display an image from Storage",
   "repository": "https://github.com/Rise-vision/rise-image.git",
   "bugs": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@polymer/iron-image": "^3.0.1",
     "@polymer/polymer": "3.1.0",
     "@webcomponents/webcomponentsjs": "^2.1.3",
-    "rise-common-component": "git://github.com/Rise-Vision/rise-common-component.git#v1.0.12"
+    "rise-common-component": "git://github.com/Rise-Vision/rise-common-component.git#chore/all-formats-invalid-error"
   },
   "devDependencies": {
     "eslint": "^5.16.0",

--- a/src/rise-image.js
+++ b/src/rise-image.js
@@ -204,7 +204,7 @@ class RiseImage extends WatchFilesMixin( ValidFilesMixin( RiseElement )) {
     }
   }
 
-  _isValidFiles( files ) {
+  _isValidFilesString( files ) {
     if ( !files || typeof files !== "string" ) {
       return false;
     }
@@ -350,12 +350,12 @@ class RiseImage extends WatchFilesMixin( ValidFilesMixin( RiseElement )) {
     const files = this.logoFile || this.files;
     let filesList;
 
-    this.stopWatch();
+    super.stopWatch();
 
     if ( !this.logoFile && this._hasMetadata()) {
       filesList = this._getFilesFromMetadata();
     } else {
-      if ( this._isValidFiles( files )) {
+      if ( this._isValidFilesString( files )) {
         filesList = files.split( "|" )
           .map( f => f.trim())
           .filter( f => f.length > 0 );
@@ -364,7 +364,7 @@ class RiseImage extends WatchFilesMixin( ValidFilesMixin( RiseElement )) {
       }
     }
 
-    const { validFiles } = this.validateFiles( filesList, VALID_FILE_TYPES );
+    const { validFiles } = super.validateFiles( filesList, VALID_FILE_TYPES );
 
     if ( !validFiles || !validFiles.length ) {
       this._validFiles = [];
@@ -372,7 +372,7 @@ class RiseImage extends WatchFilesMixin( ValidFilesMixin( RiseElement )) {
       return this._startEmptyPlayUntilDoneTimer();
     } else {
       this._validFiles = validFiles;
-      this.startWatch( validFiles );
+      super.startWatch( validFiles );
 
       if ( RisePlayerConfiguration.isPreview()) {
         this._handleStartForPreview();
@@ -384,7 +384,7 @@ class RiseImage extends WatchFilesMixin( ValidFilesMixin( RiseElement )) {
     this._validFiles = [];
     this._filesToRenderList = [];
 
-    this.stopWatch();
+    super.stopWatch();
     this._clearDisplayedImage();
 
     timeOut.cancel( this._transitionTimer );
@@ -417,7 +417,7 @@ class RiseImage extends WatchFilesMixin( ValidFilesMixin( RiseElement )) {
   }
 
   _handleStartForPreview() {
-    this._validFiles.forEach( file => this.handleFileStatusUpdated({
+    this._validFiles.forEach( file => super.handleFileStatusUpdated({
       filePath: file,
       fileUrl: RiseImage.STORAGE_PREFIX + encodeURIComponent( file ) + "?_=" +
         this._timeCreatedFor( file ),

--- a/src/rise-image.js
+++ b/src/rise-image.js
@@ -109,9 +109,10 @@ class RiseImage extends WatchFilesMixin( ValidFilesMixin( RiseElement )) {
 
   constructor() {
     super();
-
     this._setVersion( version );
 
+    this._validFiles = [];
+    this._filesToRenderList = [];
     this._initialStart = true;
     this._transitionIndex = 0;
     this._transitionTimer = null;
@@ -315,7 +316,7 @@ class RiseImage extends WatchFilesMixin( ValidFilesMixin( RiseElement )) {
   }
 
   _configureShowingImages() {
-    this._filesToRenderList = this._managedFiles
+    this._filesToRenderList = this.managedFiles
       .slice( 0 )
       .filter( f => this._validFiles.includes( f.filePath ));
 
@@ -338,7 +339,7 @@ class RiseImage extends WatchFilesMixin( ValidFilesMixin( RiseElement )) {
 
     this.stopWatch();
 
-    if ( this._hasMetadata()) {
+    if ( !this.logoFile && this._hasMetadata()) {
       filesList = this._getFilesFromMetadata();
     } else {
       filesList = files.split( "|" )
@@ -349,10 +350,15 @@ class RiseImage extends WatchFilesMixin( ValidFilesMixin( RiseElement )) {
     const { validFiles } = this.validateFiles( filesList, VALID_FILE_TYPES );
 
     if ( !validFiles || !validFiles.length ) {
+      this._validFiles = [];
+
       return this._startEmptyPlayUntilDoneTimer();
     } else {
+      this._validFiles = validFiles;
+      this.startWatch( validFiles );
+
       if ( RisePlayerConfiguration.isPreview()) {
-        return this._handleStartForPreview();
+        this._handleStartForPreview();
       }
     }
   }
@@ -394,7 +400,7 @@ class RiseImage extends WatchFilesMixin( ValidFilesMixin( RiseElement )) {
   }
 
   _handleStartForPreview() {
-    this._filesList.forEach( file => this._handleImageStatusUpdated({
+    this._validFiles.forEach( file => this.handleFileStatusUpdated({
       filePath: file,
       fileUrl: RiseImage.STORAGE_PREFIX + encodeURIComponent( file ) + "?_=" +
         this._timeCreatedFor( file ),
@@ -420,8 +426,6 @@ class RiseImage extends WatchFilesMixin( ValidFilesMixin( RiseElement )) {
   }
 
   watchedFileErrorCallback() {
-    this._configureShowingImages();
-
     if ( !this._filesToRenderList.length ) {
       this._done();
       this._startEmptyPlayUntilDoneTimer();
@@ -439,8 +443,6 @@ class RiseImage extends WatchFilesMixin( ValidFilesMixin( RiseElement )) {
     if ( this._filesToRenderList.length === 1 && this._filePathIsRendered( filePath )) {
       this._filesToRenderList = [];
       this._clearDisplayedImage();
-    } else {
-      this._configureShowingVideos();
     }
   }
 

--- a/src/rise-image.js
+++ b/src/rise-image.js
@@ -204,6 +204,19 @@ class RiseImage extends WatchFilesMixin( ValidFilesMixin( RiseElement )) {
     }
   }
 
+  _isValidFiles( files ) {
+    if ( !files || typeof files !== "string" ) {
+      return false;
+    }
+
+    // single symbol
+    if ( files.indexOf( "|" ) === -1 ) {
+      return true;
+    }
+
+    return files.split( "|" ).indexOf( "" ) === -1;
+  }
+
   _getDataUrlFromSVGLocalUrl( file, localUrl ) {
     return new Promise(( resolve, reject ) => {
       const xhr = new XMLHttpRequest();
@@ -342,9 +355,13 @@ class RiseImage extends WatchFilesMixin( ValidFilesMixin( RiseElement )) {
     if ( !this.logoFile && this._hasMetadata()) {
       filesList = this._getFilesFromMetadata();
     } else {
-      filesList = files.split( "|" )
-        .map( f => f.trim())
-        .filter( f => f.length > 0 );
+      if ( this._isValidFiles( files )) {
+        filesList = files.split( "|" )
+          .map( f => f.trim())
+          .filter( f => f.length > 0 );
+      } else {
+        filesList = [];
+      }
     }
 
     const { validFiles } = this.validateFiles( filesList, VALID_FILE_TYPES );
@@ -426,6 +443,8 @@ class RiseImage extends WatchFilesMixin( ValidFilesMixin( RiseElement )) {
   }
 
   watchedFileErrorCallback() {
+    super._setUptimeError( true );
+
     if ( !this._filesToRenderList.length ) {
       this._done();
       this._startEmptyPlayUntilDoneTimer();

--- a/src/rise-image.js
+++ b/src/rise-image.js
@@ -3,10 +3,14 @@
 import { RiseElement } from "rise-common-component/src/rise-element.js";
 import { html } from "@polymer/polymer/lib/utils/html-tag.js";
 import { timeOut } from "@polymer/polymer/lib/utils/async.js";
+import { WatchFilesMixin } from "rise-common-component/src/watch-files-mixin";
+import { ValidFilesMixin } from "rise-common-component/src/valid-files-mixin";
 import { version } from "./rise-image-version.js";
 import "@polymer/iron-image/iron-image.js";
 
-class RiseImage extends RiseElement {
+export const VALID_FILE_TYPES = [ "jpg", "jpeg", "png", "bmp", "svg", "gif", "webp" ];
+
+class RiseImage extends WatchFilesMixin( ValidFilesMixin( RiseElement )) {
   static get template() {
     return html`
       <style>
@@ -108,12 +112,7 @@ class RiseImage extends RiseElement {
 
     this._setVersion( version );
 
-    this._watchInitiated = false;
     this._initialStart = true;
-    this._filesList = [];
-    this._managedFiles = [];
-    this._managedFilesInError = [];
-    this._filesToRenderList = [];
     this._transitionIndex = 0;
     this._transitionTimer = null;
   }
@@ -164,14 +163,6 @@ class RiseImage extends RiseElement {
     return filePath.substr( filePath.lastIndexOf( "." ) + 1 ).toLowerCase();
   }
 
-  _getManagedFileInError( filePath ) {
-    return this._managedFilesInError.find( file => file.filePath === filePath );
-  }
-
-  _getManagedFile( filePath ) {
-    return this._managedFiles.find( file => file.filePath === filePath );
-  }
-
   _getFileToRender( filePath ) {
     return this._filesToRenderList.find( file => file.filePath === filePath );
   }
@@ -210,20 +201,6 @@ class RiseImage extends RiseElement {
       this._log( RiseImage.LOG_TYPE_INFO, RiseImage.EVENT_IMAGE_RESET, { files: filesToLog, isLogo: this.isLogo, logoFile: this.logoFile });
       this._start();
     }
-  }
-
-  _isValidFileType( path ) {
-    const format = this._getStorageFileFormat( path ),
-      valid = [ "jpg", "jpeg", "png", "bmp", "svg", "gif", "webp" ];
-
-
-    for ( let i = 0, len = valid.length; i < len; i++ ) {
-      if ( format.indexOf( valid[ i ]) !== -1 ) {
-        return true;
-      }
-    }
-
-    return false;
   }
 
   _getDataUrlFromSVGLocalUrl( file, localUrl ) {
@@ -265,42 +242,6 @@ class RiseImage extends RiseElement {
     });
   }
 
-  _isValidFiles( files ) {
-    if ( !files || typeof files !== "string" ) {
-      return false;
-    }
-
-    // single symbol
-    if ( files.indexOf( "|" ) === -1 ) {
-      return true;
-    }
-
-    return files.split( "|" ).indexOf( "" ) === -1;
-  }
-
-  _filterInvalidFileTypes( files ) {
-    let invalidFiles = [];
-    const filteredFiles = files.filter( file => {
-      const valid = this._isValidFileType( file );
-
-      if ( !valid ) {
-        invalidFiles.push( file );
-      }
-
-      return valid;
-    });
-
-    invalidFiles.forEach( invalidFile => {
-      this._log( RiseImage.LOG_TYPE_ERROR, "image-format-invalid", null, { storage: this._getStorageData( invalidFile ) });
-    });
-
-    if ( !filteredFiles || filteredFiles.length === 0 ) {
-      this._sendImageEvent( RiseImage.EVENT_IMAGE_ERROR, { files, errorMessage: "All file formats are invalid" });
-    }
-
-    return filteredFiles;
-  }
-
   _renderImage( filePath, fileUrl ) {
     if ( this.responsive ) {
       this.$.image.updateStyles({ "--iron-image-width": "100%", "width": "100%", "height": "auto", "display": "inline-block" });
@@ -335,10 +276,14 @@ class RiseImage extends RiseElement {
     return this._transitionIndex === this._filesToRenderList.length - 1 && this.hasAttribute( "play-until-done" );
   }
 
-  _onShowImageComplete() {
+  _done() {
     if ( this._isDone()) {
       super._sendDoneEvent( true );
     }
+  }
+
+  _onShowImageComplete() {
+    this._done();
 
     if ( this._transitionIndex < ( this._filesToRenderList.length - 1 )) {
       this._transitionIndex += 1;
@@ -370,7 +315,10 @@ class RiseImage extends RiseElement {
   }
 
   _configureShowingImages() {
-    this._filesToRenderList = this._managedFiles.slice( 0 );
+    this._filesToRenderList = this._managedFiles
+      .slice( 0 )
+      .filter( f => this._validFiles.includes( f.filePath ));
+
     this._transitionIndex = 0;
 
     if ( this._filesToRenderList.length > 0 ) {
@@ -384,105 +332,39 @@ class RiseImage extends RiseElement {
     }
   }
 
-  _manageFileInError( details, fixed ) {
-    const { filePath, params } = details;
-
-    if ( !filePath ) {
-      return;
-    }
-
-    let fileInError = this._getManagedFileInError( filePath );
-
-    if ( fixed && fileInError ) {
-      // remove this file from files in error list
-      this._managedFilesInError.splice( this._managedFilesInError.findIndex( file => file.filePath === filePath ), 1 );
-    } else if ( !fixed ) {
-      if ( !fileInError ) {
-        fileInError = { filePath, params };
-        // add this file to list of files in error
-        this._managedFilesInError.push( fileInError );
-      } else {
-        fileInError.params = params;
-      }
-    }
-  }
-
-  _manageFile( message ) {
-    const { filePath, status, fileUrl } = message;
-
-    let managedFile = this._getManagedFile( filePath );
-
-    if ( status.toUpperCase() === "CURRENT" ) {
-      if ( !managedFile ) {
-        // get the order that this file should be in from _filesList
-        const order = this._filesList.findIndex( path => path === filePath );
-
-        managedFile = { filePath, fileUrl, order };
-
-        // add this file to list
-        this._managedFiles.push( managedFile );
-      } else {
-        // file has been updated
-        managedFile.fileUrl = fileUrl;
-      }
-    }
-
-    if ( status.toUpperCase() === "DELETED" && managedFile ) {
-      this._managedFiles.splice( this._managedFiles.findIndex( file => file.filePath === filePath ), 1 );
-    }
-
-    // sort the managed files based on order value
-    this._managedFiles.sort(( a, b ) => a.order - b.order );
-  }
-
   _start() {
-    var files = this.logoFile || this.files;
+    const files = this.logoFile || this.files;
+    let filesList;
 
-    if ( this.logoFile || !this._hasMetadata()) {
-      if ( !this._isValidFiles( files )) {
-        return this._startEmptyPlayUntilDoneTimer();
-      }
+    this.stopWatch();
 
-      this._filesList = this._filterInvalidFileTypes( files.split( "|" ));
+    if ( this._hasMetadata()) {
+      filesList = this._getFilesFromMetadata();
     } else {
-      const filesArray = this._getFilesFromMetadata();
-
-      // validate metadata files
-      if ( !filesArray || !filesArray.length || filesArray.length === 0 ) {
-        return this._startEmptyPlayUntilDoneTimer();
-      }
-
-      this._filesList = this._filterInvalidFileTypes( filesArray );
+      filesList = files.split( "|" )
+        .map( f => f.trim())
+        .filter( f => f.length > 0 );
     }
 
-    if ( !this._filesList || !this._filesList.length || this._filesList.length === 0 ) {
+    const { validFiles } = this.validateFiles( filesList, VALID_FILE_TYPES );
+
+    if ( !validFiles || !validFiles.length ) {
       return this._startEmptyPlayUntilDoneTimer();
-    }
-
-    if ( RisePlayerConfiguration.isPreview()) {
-      return this._handleStartForPreview();
-    }
-
-    if ( !this._watchInitiated ) {
-      this._filesList.forEach( file => {
-        RisePlayerConfiguration.LocalStorage.watchSingleFile(
-          file, message => this._handleSingleFileUpdate( message )
-        );
-      });
-
-      this._watchInitiated = true;
+    } else {
+      if ( RisePlayerConfiguration.isPreview()) {
+        return this._handleStartForPreview();
+      }
     }
   }
 
   _stop() {
-    timeOut.cancel( this._transitionTimer );
+    this._validFiles = [];
+    this._filesToRenderList = [];
+
+    this.stopWatch();
     this._clearDisplayedImage();
 
-    this._watchInitiated = false;
-    this._filesList = [];
-    this._managedFiles = [];
-    this._managedFilesInError = [];
-    this._filesToRenderList = [];
+    timeOut.cancel( this._transitionTimer );
     this._transitionTimer = null;
     this._transitionIndex = 0;
   }
@@ -537,98 +419,33 @@ class RiseImage extends RiseElement {
     super.log( type, event, details, additionalFields );
   }
 
-  _handleSingleFileError( message ) {
-    const { filePath, fileUrl } = message,
-      details = { filePath, errorMessage: message.errorMessage, errorDetail: message.errorDetail },
-      fileInError = this._getManagedFileInError( filePath ),
-      errorName = ( "NOEXIST" === message.status.toUpperCase() && !message.errorMessage ) ? "file-not-found" :
-        ( message.errorMessage === "Insufficient disk space" ? "file-insufficient-disk-space-error" : "image-rls-error" );
+  watchedFileErrorCallback() {
+    this._configureShowingImages();
 
-    // prevent repetitive logging when component instance is receiving messages from other potential component instances watching same file
-    // Note: to avoid using Lodash or Underscore library for just a .isEqual() function, taking a simple approach to object comparison with JSON.stringify()
-    // as the property order will not change and the data is not large for this object
-    if ( fileInError && ( JSON.stringify( details ) === JSON.stringify( fileInError.details ))) {
-      return;
-    }
-
-    this._manageFileInError( details, false );
-
-    /*** Possible error messages from Local Storage ***/
-    /*
-      "File's host server could not be reached"
-
-      "File I/O Error"
-
-      "Could not retrieve signed URL"
-
-      "Insufficient disk space"
-
-      "Invalid response with status code [CODE]"
-     */
-
-    this._log( RiseImage.LOG_TYPE_ERROR, errorName, {
-      errorMessage: message.errorMessage,
-      errorDetail: message.errorDetail
-    }, { storage: this._getStorageData( filePath, fileUrl ) });
-
-    this._sendImageEvent( RiseImage.EVENT_IMAGE_ERROR, details );
-
-
-    if ( this._getManagedFile( filePath )) {
-      // remove this file from the file list since there was a problem with its new version being provided
-      this._manageFile({ filePath, status: "deleted" });
-
-      if ( this._filesToRenderList.length === 1 && this._getFileToRender( message.filePath )) {
-        this._filesToRenderList = [];
-        this._clearDisplayedImage();
-      }
-    }
-
-    //if all requested files have errors, then trigger PUD
-    if ( this._filesList ) {
-      const allFilesHaveErrors = this._filesList.every( filePath => {
-        return this._getManagedFileInError( filePath );
-      });
-
-      if ( allFilesHaveErrors ) {
-        this._startEmptyPlayUntilDoneTimer();
-      }
+    if ( !this._filesToRenderList.length ) {
+      this._done();
+      this._startEmptyPlayUntilDoneTimer();
     }
   }
 
-  _handleSingleFileUpdate( message ) {
-    if ( !message.status || !message.filePath ) {
-      return;
-    }
-
-    if ( this._filesList && this._filesList.indexOf( message.filePath ) === -1 ) {
-      return;
-    }
-
-    if ( message.status.toUpperCase() === "FILE-ERROR" || message.status.toUpperCase() === "NOEXIST" ) {
-      this._handleSingleFileError( message );
-      return;
-    }
-
-    this._handleImageStatusUpdated( message );
+  watchedFileAddedCallback() {
+    this._configureShowingImages();
   }
 
-  _handleImageStatusUpdated( message ) {
-    const { filePath, status } = message;
 
-    this._manageFile( message );
-    this._manageFileInError( message, true );
+  watchedFileDeletedCallback( details ) {
+    const { filePath } = details;
 
-    if ( this._filesToRenderList.length === 1 && status.toUpperCase() === "DELETED" && this._filesToRenderList.find( file => file.filePath === filePath )) {
+    if ( this._filesToRenderList.length === 1 && this._filePathIsRendered( filePath )) {
       this._filesToRenderList = [];
       this._clearDisplayedImage();
-
-      return;
+    } else {
+      this._configureShowingVideos();
     }
+  }
 
-    if ( status.toUpperCase() === "CURRENT" ) {
-      this._configureShowingImages();
-    }
+  _filePathIsRendered( filePath ) {
+    return this._filesToRenderList.find( file => file.filePath === filePath );
   }
 
   _sendImageEvent( eventName, detail = {}) {

--- a/test/integration/rise-image-logging.html
+++ b/test/integration/rise-image-logging.html
@@ -80,7 +80,7 @@
       assert.deepEqual( RisePlayerConfiguration.Logger.info.args[ 0 ][ 2 ], { files: SAMPLE_PATH, isLogo: false, logoFile: "" } );
     });
 
-    test( "should log an 'image-rls-error' event when FILE-ERROR is received", () => {
+    test( "should log an 'file-rls-error' event when FILE-ERROR is received", () => {
       RisePlayerConfiguration.LocalStorage.watchSingleFile = ( file, handler ) => {
           handler({
               filePath: SAMPLE_PATH,
@@ -96,7 +96,7 @@
         assert.equal( RisePlayerConfiguration.Logger.info.callCount, 1 ); // start
 
         assert.deepEqual( RisePlayerConfiguration.Logger.error.args[ 0 ][ 0 ], componentData );
-        assert.equal( RisePlayerConfiguration.Logger.error.args[ 0 ][ 1 ], "image-rls-error");
+        assert.equal( RisePlayerConfiguration.Logger.error.args[ 0 ][ 1 ], "file-rls-error");
         assert.deepEqual( RisePlayerConfiguration.Logger.error.args[ 0 ][ 2 ], {
             errorMessage: "image download error",
             errorDetail: "network failure"
@@ -154,7 +154,7 @@
         } );
     });
 
-    test( "should log an 'image-format-invalid' event when file type is invalid", () => {
+    test( "should log a 'format-invalid' event when file type is invalid", () => {
         element.files = "risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/test.txt";
 
         element.dispatchEvent( new CustomEvent( "start" ));
@@ -162,7 +162,7 @@
         assert.equal( RisePlayerConfiguration.Logger.info.callCount, 1 ); // start
 
         assert.deepEqual( RisePlayerConfiguration.Logger.error.args[ 0 ][ 0 ], componentData );
-        assert.equal( RisePlayerConfiguration.Logger.error.args[ 0 ][ 1 ], "image-format-invalid");
+        assert.equal( RisePlayerConfiguration.Logger.error.args[ 0 ][ 1 ], "format-invalid");
         assert.isNull( RisePlayerConfiguration.Logger.error.args[ 0 ][ 2 ]);
         assert.deepEqual( RisePlayerConfiguration.Logger.error.args[ 0 ][ 3 ], {
             storage: {

--- a/test/integration/rise-image-logo.html
+++ b/test/integration/rise-image-logo.html
@@ -162,33 +162,29 @@
         };
       });
 
-      test('it should send an image error event if an image local storage error was received', (done) => {
-        element.addEventListener('image-error', event => {
-          assert.deepEqual( event.detail, {
+      test('it should call watchedFileErrorCallback if an image local storage error was received', () => {
+        sinon.spy( element, "watchedFileErrorCallback" );
+
+        element.dispatchEvent( new CustomEvent( "start" ) );
+
+        assert.deepEqual( element.watchedFileErrorCallback.lastCall.args[0], {
             filePath: LOGO_PATH,
             errorMessage: "image download error",
             errorDetail: "network failure"
           });
-
-          done();
-        });
-
-        element.dispatchEvent( new CustomEvent( "start" ) );
       });
 
-      test('it should send an image error event when the single file type is invalid', done => {
-        element.addEventListener('image-error', event => {
-          assert.deepEqual( event.detail, {
-            files: [ "risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/test.txt" ],
-            errorMessage: "All file formats are invalid"
-          });
-
-          done();
-        });
+      test('it should send an error event when all file types are invalid', () => {
+        sinon.spy( RisePlayerConfiguration.Logger, "error" );
 
         element._setLogoFile("risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/test.txt");
-
         element.dispatchEvent( new CustomEvent( "start" ) );
+
+        assert.equal( RisePlayerConfiguration.Logger.error.lastCall.args[1], "all-formats-invalid" );
+        assert.deepEqual( RisePlayerConfiguration.Logger.error.lastCall.args[3], {
+          files: [ "risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/test.txt" ],
+          errorMessage: "All file formats are invalid"
+        });
       });
 
       test("should send an image error event when failed to render an SVG file", done => {

--- a/test/integration/rise-image-logo.html
+++ b/test/integration/rise-image-logo.html
@@ -174,7 +174,7 @@
           });
       });
 
-      test('it should send an error event when all file types are invalid', () => {
+      test('it should send an error event when the logo file type is invalid', () => {
         sinon.spy( RisePlayerConfiguration.Logger, "error" );
 
         element._setLogoFile("risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/test.txt");

--- a/test/integration/rise-image-logo.html
+++ b/test/integration/rise-image-logo.html
@@ -181,7 +181,7 @@
         element.dispatchEvent( new CustomEvent( "start" ) );
 
         assert.equal( RisePlayerConfiguration.Logger.error.lastCall.args[1], "all-formats-invalid" );
-        assert.deepEqual( RisePlayerConfiguration.Logger.error.lastCall.args[3], {
+        assert.deepEqual( RisePlayerConfiguration.Logger.error.lastCall.args[2], {
           files: [ "risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/test.txt" ],
           errorMessage: "All file formats are invalid"
         });

--- a/test/integration/rise-image-multiple.html
+++ b/test/integration/rise-image-multiple.html
@@ -180,7 +180,6 @@
           status: "FILE-ERROR",
           errorMessage: "image download error",
           errorDetail: "network failure"
-
         } );
 
         // emulate cycling 2nd and third images, to be back to start again

--- a/test/integration/rise-image-single.html
+++ b/test/integration/rise-image-single.html
@@ -164,6 +164,15 @@
         });
       });
 
+      test('it should not call startWatch when the single file type is invalid', () => {
+        sinon.spy( element.__proto__.__proto__, "startWatch" );
+
+        element.files = "risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/test.txt";
+        element.dispatchEvent( new CustomEvent( "start" ) );
+
+        assert.strictEqual( element.__proto__.__proto__.startWatch.callCount, 0 );
+      });
+
       test("should send an image error event when failed to render an SVG file", done => {
         const svgFilePath = "risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f/rise-image-demo/PokemonGO-Team-Logos-Instinct.svg",
           svgFileUrl = `https://storage.googleapis.com/${svgFilePath}`;

--- a/test/integration/rise-image-single.html
+++ b/test/integration/rise-image-single.html
@@ -152,33 +152,16 @@
         };
       });
 
-      test('it should send an image error event if an image local storage error was received', (done) => {
-        element.addEventListener('image-error', event => {
-          assert.deepEqual( event.detail, {
-            filePath: SAMPLE_PATH,
-            errorMessage: "image download error",
-            errorDetail: "network failure"
-          });
-
-          done();
-        });
+      test('it should call watchedFileErrorCallback if a local storage error was received', () => {
+        sinon.spy( element, "watchedFileErrorCallback" );
 
         element.dispatchEvent( new CustomEvent( "start" ) );
-      });
 
-      test('it should send an image error event when the single file type is invalid', done => {
-        element.addEventListener('image-error', event => {
-          assert.deepEqual( event.detail, {
-            files: [ "risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/test.txt" ],
-            errorMessage: "All file formats are invalid"
-          });
-
-          done();
+        assert.deepEqual( element.watchedFileErrorCallback.lastCall.args[0], {
+          filePath: SAMPLE_PATH,
+          errorMessage: "image download error",
+          errorDetail: "network failure"
         });
-
-        element.files = "risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/test.txt";
-
-        element.dispatchEvent( new CustomEvent( "start" ) );
       });
 
       test("should send an image error event when failed to render an SVG file", done => {

--- a/test/unit/rise-image.html
+++ b/test/unit/rise-image.html
@@ -56,29 +56,6 @@
           element = fixture("test-block");
         });
 
-        suite( "_isValidFiles", () => {
-          test( "should return true if 'files' attribute is a non-empty String", () => {
-            assert.isTrue( element._isValidFiles( "test" ) );
-          } );
-
-          test( "should return false if 'files' attribute is not a String or empty String", () => {
-            assert.isFalse( element._isValidFiles( 123 ) );
-            assert.isFalse( element._isValidFiles( ["test1|test2"] ) );
-            assert.isFalse( element._isValidFiles( "" ) );
-          } );
-
-          test( "should return true if 'files' attribute is a String containing values separated by '|'", () => {
-            assert.isTrue( element._isValidFiles( "test1|test2|test3" ) );
-          } );
-
-          test( "should return false if 'files' attribute contains '|' with any empty value", () => {
-            assert.isFalse(element._isValidFiles("test|"));
-            assert.isFalse(element._isValidFiles("|test"));
-            assert.isFalse(element._isValidFiles("|"));
-            assert.isFalse(element._isValidFiles("test1|test2||test3"));
-          } );
-        } );
-
         suite( "_getStorageFileFormat", () => {
           test( "should return correct format from file path", () => {
             assert.equal( element._getStorageFileFormat( SAMPLE_PATH ), "png" );
@@ -193,18 +170,6 @@
           } );
         } );
 
-        suite( "_filterInvalidFileTypes", () => {
-          test( "should return filtered files list", () => {
-            assert.deepEqual( element._filterInvalidFileTypes( [ "test1.jpg", "test2.gif", "test3.txt", "test4.png", "test5.webm" ] ), [
-              "test1.jpg", "test2.gif", "test4.png"
-            ] )
-          } );
-
-          test( "should return empty list", () => {
-            assert.deepEqual( element._filterInvalidFileTypes( [ "test1.webm", "test2.text", "test3.mov" ] ), [] );
-          } );
-        } );
-
         suite( "_reset", () => {
           setup( () => {
             sinon.stub( element, "_start" );
@@ -219,17 +184,17 @@
 
             element._initialStart = false;
             element._watchInitiated = true;
-            element._filesList = [ SAMPLE_PATH ];
-            element._managedFiles = [ { filePath: SAMPLE_PATH, fileUrl: SAMPLE_URL, order: 0 } ];
+            element._validFiles = [ SAMPLE_PATH ];
+            element.managedFiles = [ { filePath: SAMPLE_PATH, fileUrl: SAMPLE_URL, order: 0 } ];
             element._filesToRenderList = [ { filePath: SAMPLE_PATH, fileUrl: SAMPLE_URL, order: 0 } ];
-            element._managedFilesInError= [ { filePath: "test path", fileUrl: "test url", order: 1 } ];
+            element._managedFilesInError = [ { filePath: "test path", fileUrl: "test url", order: 1 } ];
             element._transitionTimer = 12345;
             element._transitionIndex = 3;
             element._reset();
 
             assert.isFalse( element._watchInitiated );
-            assert.isEmpty( element._filesList );
-            assert.isEmpty( element._managedFiles );
+            assert.isEmpty( element._validFiles );
+            assert.isEmpty( element.managedFiles );
             assert.isEmpty( element._managedFilesInError );
             assert.isEmpty( element._filesToRenderList );
             assert.isNull( element._transitionTimer );
@@ -288,58 +253,58 @@
 
         suite( "_handleStartForPreview", () => {
           setup( () => {
-            sinon.stub(element, "_handleImageStatusUpdated");
+            sinon.stub(element, "handleFileStatusUpdated");
           });
 
           teardown( () => {
             element.metadata = null;
 
-            element._handleImageStatusUpdated.restore();
+            element.handleFileStatusUpdated.restore();
           } );
 
-          test( "should call _handleImageStatusUpdated with correct data", () => {
-            element._filesList = [ "risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/logo.png" ];
+          test( "should call handleFileStatusUpdated with correct data", () => {
+            element._validFiles = [ "risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/logo.png" ];
             element._handleStartForPreview();
 
-            assert.isTrue( element._handleImageStatusUpdated.calledWith({
+            assert.isTrue( element.handleFileStatusUpdated.calledWith({
               filePath: "risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/logo.png",
               fileUrl: "https://storage.googleapis.com/risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013%2Flogo.png?_=",
               status: "current"
             } ));
           } );
 
-          test( "should call _handleImageStatusUpdated for each file", () => {
-            element._filesList = [ "risemedialibrary-abc123/test1.png", "risemedialibrary-abc123/test2.png", "risemedialibrary-abc123/test3.png" ];
+          test( "should call handleFileStatusUpdated for each file", () => {
+            element._validFiles = [ "risemedialibrary-abc123/test1.png", "risemedialibrary-abc123/test2.png", "risemedialibrary-abc123/test3.png" ];
             element._handleStartForPreview();
 
-            assert.deepEqual( element._handleImageStatusUpdated.args[0][0], {
+            assert.deepEqual( element.handleFileStatusUpdated.args[0][0], {
               filePath: "risemedialibrary-abc123/test1.png",
               fileUrl: "https://storage.googleapis.com/risemedialibrary-abc123%2Ftest1.png?_=",
               status: "current"
             } );
 
-            assert.deepEqual( element._handleImageStatusUpdated.args[1][0], {
+            assert.deepEqual( element.handleFileStatusUpdated.args[1][0], {
               filePath: "risemedialibrary-abc123/test2.png",
               fileUrl: "https://storage.googleapis.com/risemedialibrary-abc123%2Ftest2.png?_=",
               status: "current"
             } );
 
-            assert.deepEqual( element._handleImageStatusUpdated.args[2][0], {
+            assert.deepEqual( element.handleFileStatusUpdated.args[2][0], {
               filePath: "risemedialibrary-abc123/test3.png",
               fileUrl: "https://storage.googleapis.com/risemedialibrary-abc123%2Ftest3.png?_=",
               status: "current"
             } );
           } );
 
-          test( "should call _handleImageStatusUpdated with correct data and time created", () => {
+          test( "should call handleFileStatusUpdated with correct data and time created", () => {
             const file = "risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/logo.png";
-            element._filesList = [ file ];
+            element._validFiles = [ file ];
             element.metadata = [
               { file, exists: true, "time-created": 123 }
             ];
             element._handleStartForPreview();
 
-            assert.isTrue( element._handleImageStatusUpdated.calledWith({
+            assert.isTrue( element.handleFileStatusUpdated.calledWith({
               filePath: "risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/logo.png",
               fileUrl: "https://storage.googleapis.com/risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013%2Flogo.png?_=123",
               status: "current"
@@ -499,7 +464,7 @@
               element.setAttribute( "play-until-done", true);
 
               element._transitionIndex = 0;
-              element._filesList = [ SAMPLE_PATH ];
+              element._validFiles = [ SAMPLE_PATH ];
 
               element._handleSingleFileError({filePath: SAMPLE_PATH, status: "NOEXIST"});
 
@@ -510,7 +475,7 @@
               element.setAttribute( "play-until-done", true);
 
               element._transitionIndex = 0;
-              element._filesList = [ SAMPLE_PATH,  SAMPLE_PATH2];
+              element._validFiles = [ SAMPLE_PATH,  SAMPLE_PATH2];
 
               element._handleSingleFileError({filePath: SAMPLE_PATH, status: "NOEXIST"});
               element._handleSingleFileError({filePath: SAMPLE_PATH2, status: "NOEXIST"});
@@ -522,7 +487,7 @@
               element.setAttribute( "play-until-done", true);
 
               element._transitionIndex = 0;
-              element._filesList = [ SAMPLE_PATH,  SAMPLE_PATH];
+              element._validFiles = [ SAMPLE_PATH,  SAMPLE_PATH];
 
               element._handleSingleFileError({filePath: SAMPLE_PATH, status: "NOEXIST"});
 
@@ -541,7 +506,7 @@
 
             test( "should call _isLogoChanged when isLogo is changed", () => {
               sinon.stub(element, "_isLogoChanged");
-              
+
               element.isLogo = true;
 
               assert.isTrue( element._isLogoChanged.called );
@@ -613,7 +578,7 @@
               assert.isTrue( RisePlayerConfiguration.Branding.watchLogoFile.calledOnce );
 
               element.isLogo = false;
-              
+
               assert.isTrue( RisePlayerConfiguration.Branding.watchLogoFile.calledOnce );
               assert.isTrue( unregisterSpy.calledOnce );
             });
@@ -624,7 +589,7 @@
               assert.isTrue( RisePlayerConfiguration.Branding.watchLogoFile.calledOnce );
 
               element.isLogo = false;
-              
+
               assert.isTrue( unregisterSpy.calledOnce );
 
               element._isLogoChanged();
@@ -653,10 +618,10 @@
               }, {
                 "file": "risemedialibrary-abc123/README.md",
                 "exists": true
-              }];              
+              }];
             });
 
-            test( "should set _filesList to logoFile if it exists", () => {
+            test( "should set _validFiles to logoFile if it exists", () => {
               assert.isOk( element.files );
               assert.isOk( element.metadata );
 
@@ -664,10 +629,10 @@
 
               element._start();
 
-              assert.deepEqual( element._filesList, [ "risemedialibrary-abc123/testFile.jpg" ]);
+              assert.deepEqual( element._validFiles, [ "risemedialibrary-abc123/testFile.jpg" ]);
             });
 
-            test( "should set _filesList to metadata if logoFile is balnk", () => {
+            test( "should set _validFiles to metadata if logoFile is blank", () => {
               assert.isOk( element.files );
               assert.isOk( element.metadata );
 
@@ -675,10 +640,10 @@
 
               element._start();
 
-              assert.deepEqual( element._filesList, [ "risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f/apache.png" ]);
+              assert.deepEqual( element._validFiles, [ "risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f/apache.png" ]);
             });
 
-            test( "should set _filesList to files if logoFile and metadata are blank", () => {
+            test( "should set _validFiles to files if logoFile and metadata are blank", () => {
               assert.isOk( element.files );
 
               element.metadata = "";
@@ -686,7 +651,7 @@
 
               element._start();
 
-              assert.deepEqual( element._filesList, [ "risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/logo.png" ]);
+              assert.deepEqual( element._validFiles, [ "risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/logo.png" ]);
             });
 
           });

--- a/test/unit/rise-image.html
+++ b/test/unit/rise-image.html
@@ -56,6 +56,26 @@
           element = fixture("test-block");
         });
 
+        suite( "_isValidFiles", () => {
+          test( "should return true if 'files' attribute is a non-empty String", () => {
+            assert.isTrue( element._isValidFiles( "test" ) );
+          } );
+           test( "should return false if 'files' attribute is not a String or empty String", () => {
+            assert.isFalse( element._isValidFiles( 123 ) );
+            assert.isFalse( element._isValidFiles( ["test1|test2"] ) );
+            assert.isFalse( element._isValidFiles( "" ) );
+          } );
+           test( "should return true if 'files' attribute is a String containing values separated by '|'", () => {
+            assert.isTrue( element._isValidFiles( "test1|test2|test3" ) );
+          } );
+           test( "should return false if 'files' attribute contains '|' with any empty value", () => {
+            assert.isFalse(element._isValidFiles("test|"));
+            assert.isFalse(element._isValidFiles("|test"));
+            assert.isFalse(element._isValidFiles("|"));
+            assert.isFalse(element._isValidFiles("test1|test2||test3"));
+          } );
+        } );
+
         suite( "_getStorageFileFormat", () => {
           test( "should return correct format from file path", () => {
             assert.equal( element._getStorageFileFormat( SAMPLE_PATH ), "png" );

--- a/test/unit/rise-image.html
+++ b/test/unit/rise-image.html
@@ -56,23 +56,23 @@
           element = fixture("test-block");
         });
 
-        suite( "_isValidFiles", () => {
+        suite( "_isValidFilesString", () => {
           test( "should return true if 'files' attribute is a non-empty String", () => {
-            assert.isTrue( element._isValidFiles( "test" ) );
+            assert.isTrue( element._isValidFilesString( "test" ) );
           } );
            test( "should return false if 'files' attribute is not a String or empty String", () => {
-            assert.isFalse( element._isValidFiles( 123 ) );
-            assert.isFalse( element._isValidFiles( ["test1|test2"] ) );
-            assert.isFalse( element._isValidFiles( "" ) );
+            assert.isFalse( element._isValidFilesString( 123 ) );
+            assert.isFalse( element._isValidFilesString( ["test1|test2"] ) );
+            assert.isFalse( element._isValidFilesString( "" ) );
           } );
            test( "should return true if 'files' attribute is a String containing values separated by '|'", () => {
-            assert.isTrue( element._isValidFiles( "test1|test2|test3" ) );
+            assert.isTrue( element._isValidFilesString( "test1|test2|test3" ) );
           } );
            test( "should return false if 'files' attribute contains '|' with any empty value", () => {
-            assert.isFalse(element._isValidFiles("test|"));
-            assert.isFalse(element._isValidFiles("|test"));
-            assert.isFalse(element._isValidFiles("|"));
-            assert.isFalse(element._isValidFiles("test1|test2||test3"));
+            assert.isFalse(element._isValidFilesString("test|"));
+            assert.isFalse(element._isValidFilesString("|test"));
+            assert.isFalse(element._isValidFilesString("|"));
+            assert.isFalse(element._isValidFilesString("test1|test2||test3"));
           } );
         } );
 
@@ -273,7 +273,7 @@
 
         suite( "_handleStartForPreview", () => {
           setup( () => {
-            sinon.stub(element, "handleFileStatusUpdated");
+            sinon.stub(element.__proto__.__proto__, "handleFileStatusUpdated");
           });
 
           teardown( () => {
@@ -297,19 +297,19 @@
             element._validFiles = [ "risemedialibrary-abc123/test1.png", "risemedialibrary-abc123/test2.png", "risemedialibrary-abc123/test3.png" ];
             element._handleStartForPreview();
 
-            assert.deepEqual( element.handleFileStatusUpdated.args[0][0], {
+            assert.deepEqual( element.__proto__.__proto__.handleFileStatusUpdated.args[0][0], {
               filePath: "risemedialibrary-abc123/test1.png",
               fileUrl: "https://storage.googleapis.com/risemedialibrary-abc123%2Ftest1.png?_=",
               status: "current"
             } );
 
-            assert.deepEqual( element.handleFileStatusUpdated.args[1][0], {
+            assert.deepEqual( element.__proto__.__proto__.handleFileStatusUpdated.args[1][0], {
               filePath: "risemedialibrary-abc123/test2.png",
               fileUrl: "https://storage.googleapis.com/risemedialibrary-abc123%2Ftest2.png?_=",
               status: "current"
             } );
 
-            assert.deepEqual( element.handleFileStatusUpdated.args[2][0], {
+            assert.deepEqual( element.__proto__.__proto__.handleFileStatusUpdated.args[2][0], {
               filePath: "risemedialibrary-abc123/test3.png",
               fileUrl: "https://storage.googleapis.com/risemedialibrary-abc123%2Ftest3.png?_=",
               status: "current"
@@ -324,7 +324,7 @@
             ];
             element._handleStartForPreview();
 
-            assert.isTrue( element.handleFileStatusUpdated.calledWith({
+            assert.isTrue( element.__proto__.__proto__.handleFileStatusUpdated.calledWith({
               filePath: "risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/logo.png",
               fileUrl: "https://storage.googleapis.com/risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013%2Flogo.png?_=123",
               status: "current"


### PR DESCRIPTION
## Description

Implement the new shared mixins from `rise-common-component`.

## Motivation and Context

Work related to [this Trello card](https://trello.com/c/GiARDdSl).

- Remove references to `image-format-invalid` and `image-rls-error` from docs, as these are now handled by `ValidFilesMixin` and `WatchFilesMixin` respectively
- Update `rise-common-component` to latest version
- Implement `WatchFilesMixin` and deprecate unneeded code
- Implement `ValidFilesMixin` and deprecate unneeded code
- Rename `_isValidFiles` to `_isValidFilesString` to prevent conflict with `ValidFilesMixin` and clarify functionality
- Update all unit tests as needed (some tests which are duplicative of tests in `rise-common-component` are removed)

## How Has This Been Tested?

Unit tests have been updated and and run against the updated component.

Additionally, the new `rise-image` component code has been deployed to [GCS here](https://widgets.risevision.com/staging/components/rise-image/2019.09.03.08.37/rise-image.js) and a test version of the `example-pud-image` template has been pushed to `stable` which points to that code.

An example presentation using `example-pud-image` has been created [here](https://apps.risevision.com/templates/edit/eda5aeb5-e52b-48e4-8afb-f6175c033b6a/?cid=7fa5ee92-7deb-450b-a8d5-e5ed648c575f) and added to [this schedule](https://apps.risevision.com/schedules/details/74b306df-7e23-485a-8d4d-5b14f818ae71?cid=7fa5ee92-7deb-450b-a8d5-e5ed648c575f).

Several different players were added to this schedule and I tested that things behaved as expected when adding or removing images, and that PUD was triggered as expected and the schedule moved through several different presentations.

Additionally, an updated demo template which points to this code was deployed [here](https://widgets.risevision.com/staging/pages/2019.09.03.08.39/src/rise-image.html) and added to the schedule to ensure that branding logos and other features demonstrated in the demo page were functioning correctly.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?

No release checklist items were skipped.