### PR TITLE
Update version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-image",
-  "version": "2.0.0",
+  "version": "1.1.3",
   "description": "Web component built for Templates to display an image from Storage",
   "repository": "https://github.com/Rise-vision/rise-image.git",
   "bugs": {


### PR DESCRIPTION
## Description

Revert to version `1.1.3` after testing.

## Motivation and Context

The version number needs to be updated back to a `1.x` version after testing was completed using an updated major version.

A release will be tagged after this is merged.

## How Has This Been Tested?

No testing was necessary, but since switching the major version will make the previous image mixin changes available to all templates (which were already tested independently) I will be monitoring for several days post-release for any issues.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?

No release checklist items were skipped.
