### PR TITLE
Only start watching files if Local Messaging is connected

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-image",
-  "version": "1.1.8",
+  "version": "1.1.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-image",
-  "version": "1.1.8",
+  "version": "1.1.9",
   "description": "Web component built for Templates to display an image from Storage",
   "repository": "https://github.com/Rise-vision/rise-image.git",
   "bugs": {

--- a/src/rise-image.js
+++ b/src/rise-image.js
@@ -357,11 +357,16 @@ class RiseImage extends WatchFilesMixin( ValidFilesMixin( RiseElement )) {
       return this._startEmptyPlayUntilDoneTimer();
     } else {
       this._validFiles = validFiles;
-      super.startWatch( validFiles );
 
       if ( RisePlayerConfiguration.isPreview()) {
-        this._handleStartForPreview();
+        return this._handleStartForPreview();
       }
+
+      if ( !RisePlayerConfiguration.LocalMessaging.isConnected()) {
+        return this._startEmptyPlayUntilDoneTimer();
+      }
+
+      super.startWatch( validFiles );
     }
   }
 

--- a/test/integration/rise-image-logging.html
+++ b/test/integration/rise-image-logging.html
@@ -19,6 +19,10 @@
           isConfigured: () => true,
           isPreview: () => false
         };
+
+        RisePlayerConfiguration.LocalMessaging = {
+          isConnected: () => { return true; }
+        }
     </script>
     <script src="../../src/rise-image.js" type="module"></script>
 </head>

--- a/test/integration/rise-image-logo.html
+++ b/test/integration/rise-image-logo.html
@@ -34,6 +34,10 @@
         warning: () => {}
       }
     };
+
+    RisePlayerConfiguration.LocalMessaging = {
+      isConnected: () => { return true; }
+    }
   </script>
   <script src="../../src/rise-image.js" type="module"></script>
 </head>
@@ -138,6 +142,20 @@
         assert.equal(element.$.image.src, "");
 
         spy.restore();
+      });
+
+      test('it should not watch logo file when LM is not connected', () => {
+        sinon.spy( element, "startWatch" );
+        sinon.spy( element, "_startEmptyPlayUntilDoneTimer" );
+
+        RisePlayerConfiguration.LocalMessaging.isConnected = () => { return false; };
+
+        element.dispatchEvent( new CustomEvent( "start" ) );
+
+        assert.isFalse(element.startWatch.called);
+        assert.isTrue(element._startEmptyPlayUntilDoneTimer.called);
+
+        RisePlayerConfiguration.LocalMessaging.isConnected = () => { return true; };
       });
 
     });

--- a/test/integration/rise-image-multiple.html
+++ b/test/integration/rise-image-multiple.html
@@ -36,6 +36,10 @@
         warning: () => {}
       }
     };
+
+    RisePlayerConfiguration.LocalMessaging = {
+      isConnected: () => { return true; }
+    }
   </script>
   <script src="../../src/rise-image.js" type="module"></script>
 </head>

--- a/test/integration/rise-image-single.html
+++ b/test/integration/rise-image-single.html
@@ -60,6 +60,10 @@
             handler({ status: "CURRENT", filePath: file, fileUrl: `https://storage.googleapis.com/${ file }` });
           }
         };
+
+        RisePlayerConfiguration.LocalMessaging = {
+          isConnected: () => { return true; }
+        }
       });
 
       teardown(() => {
@@ -130,6 +134,18 @@
         spy.restore();
       });
 
+      test('it should not watch files when LM is not connected', () => {
+        sinon.spy( element, "startWatch" );
+        sinon.spy( element, "_startEmptyPlayUntilDoneTimer" );
+
+        RisePlayerConfiguration.LocalMessaging.isConnected = () => { return false; };
+
+        element.dispatchEvent( new CustomEvent( "start" ) );
+
+        assert.isFalse(element.startWatch.called);
+        assert.isTrue(element._startEmptyPlayUntilDoneTimer.called);
+      });
+
     });
 
     suite('error', () => {
@@ -144,6 +160,10 @@
               errorDetail: "network failure"
             });
           }
+        };
+
+        RisePlayerConfiguration.LocalMessaging = {
+          isConnected: () => { return true; }
         };
       });
 

--- a/test/unit/rise-image.html
+++ b/test/unit/rise-image.html
@@ -610,6 +610,10 @@
                 "file": "risemedialibrary-abc123/README.md",
                 "exists": true
               }];
+
+              RisePlayerConfiguration.LocalMessaging = {
+                isConnected: () => { return true; }
+              }
             });
 
             test( "should set _validFiles to logoFile if it exists", () => {


### PR DESCRIPTION
## Description
When component handles a start, after file validation and preview check, it now checks if Local Messaging is connected. If it's not connected, send Done event via existing `_startEmptyPlayUntilDoneTimer()` call. Otherwise if connected, proceed with watching files. 

## Motivation and Context
This change in collaboration with the Viewer change proposed in https://github.com/Rise-Vision/viewer/pull/330 fixes issue https://github.com/Rise-Vision/rise-launcher-electron/issues/809 

## How Has This Been Tested?
Tested on VB Windows 10 x32, with Charles installed (figured out SSL proxy certificate) and a shared folder synced with local _rise-image_ project files so I could build and test my changes. I also modified the RiseDisplayNetwork INI file to target the staged Viewer branch from https://github.com/Rise-Vision/viewer/pull/330 

I used this schedule - https://apps.risevision.com/schedules/details/9be18cf4-b565-4870-a454-43dc7f43daab?cid=7fa5ee92-7deb-450b-a8d5-e5ed648c575f

I tested by turning off network adapter of VM (kill internet connection) which gets LM to disconnect. When one presentation finished and the next one started, validated no watching files occurred and instead PUD was being applied, so the presentations continuously rotated as expected. 

Then I turned network adaptor back on (restore internet connection), which gets LM to reconnect, and validated that the presentations began displaying image(s) again. 

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
  - Deploy Viewer change and validate no issues on Production 
    - Rollback involves either directing traffic back to previous deployment or rerun previous master CCI deployment
  - Deploy Image component and validate on Production
    - Rollback involves rerunning previous `build/stable` CCI deployment followed by then fixing code or reverting codebase first. 
  - Notify Support of the fix to resolve the blocked user
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
- Documentation not required
