### PR TITLE
Force no line height to avoid extra pixels in height

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-image",
-  "version": "1.1.10",
+  "version": "1.1.11",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-image",
-  "version": "1.1.10",
+  "version": "1.1.11",
   "description": "Web component built for Templates to display an image from Storage",
   "repository": "https://github.com/Rise-vision/rise-image.git",
   "bugs": {

--- a/src/rise-image.js
+++ b/src/rise-image.js
@@ -18,6 +18,7 @@ class RiseImage extends WatchFilesMixin( ValidFilesMixin( RiseElement )) {
           display: inline-block;
           overflow: hidden;
           position: relative;
+          line-height: 0;
         }
       </style>
       <iron-image id="image"></iron-image>


### PR DESCRIPTION
## Description
Forcing no line height value to be applied the `<rise-image>`  element itself. 

## Motivation and Context
This fixes issue #53 

Since the component is being rendered to display as `inline-block`, `line-height` is inherently applied causing extra space above and below the element by an undetermined amount. The fix now ensure that value is `0` preventing the extra space from being applied.

## How Has This Been Tested?
Used a staged version of Volleyball template to target this staged version of component. Can validate here:
https://apps-stage-8.risevision.com/templates/edit/8553110f-f3e3-4158-aff2-6160c9d11772/?cid=b428b4e8-c8b9-41d5-8a10-b4193c789443

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
Support, documentation - low risk
