### PR TITLE
Do not fail preinstall if package-lock.json does not exist

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "author": "Rise Vision",
   "license": "GPL-3.0+",
   "scripts": {
-    "preinstall": "npx npm-force-resolutions",
+    "preinstall": "npx npm-force-resolutions || true",
     "build": "polymer build && ./node_modules/rise-common-component/scripts/extract-source.sh rise-image",
     "pretest": "eslint .",
     "test": "polymer test --root ./ --config-file ./node_modules/rise-common-component/wct.conf.js",


### PR DESCRIPTION
## Description
Adds a `|| true` to `preinstall` to avoid build failures when `package-lock.json` does not exist. 

## Motivation and Context
Builds on `html-template-library` were failing because `package-lock.json` was not found.

## How Has This Been Tested?
We need to merge to validate the `html-template-library` build passes.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No.

@santiagonoguez @stulees please review
