### PR TITLE
Ignore metadata if isLogo in order to work with Preview/Shared Schedules

### DIFF
--- a/src/rise-image.js
+++ b/src/rise-image.js
@@ -380,7 +380,7 @@ class RiseImage extends WatchFilesMixin( ValidFilesMixin( RiseElement )) {
   }
 
   _previewStatusFor( file ) {
-    if ( !this._hasMetadata()) {
+    if ( this.isLogo || !this._hasMetadata()) {
       return "current";
     }
 

--- a/test/unit/rise-image.html
+++ b/test/unit/rise-image.html
@@ -696,6 +696,18 @@
             assert.equal( status, "current" );
           });
 
+          test( "should ignore metadata and return 'current' status if is logo", () => {
+            element.metadata = [{
+              "file": "risemedialibrary-abc123/logo.png",
+              "exists": false
+            }];
+            element.isLogo = true;
+
+            const status = element._previewStatusFor( 'risemedialibrary-abc123/logo.png' );
+
+            assert.equal( status, "current" );
+          });
+
           test( "should get current status if metadata says that file exists", () => {
             element.metadata = [{
               "file": "risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f/apache.png",


### PR DESCRIPTION
## Description
Ignore metadata if isLogo in order to work with Preview/Shared Schedules.
Metadata is populated with attribute data and was causing the logo to not appear.

## Motivation and Context
Shared Schedules epic / branding logo.

## How Has This Been Tested?
Tested both in [Viewer](https://github.com/Rise-Vision/viewer/pull/364) and [Apps](https://github.com/Rise-Vision/rise-vision-apps/pull/1636) branches. 
Players are not affected as this is from `_previewStatus()`.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
