### PR TITLE
Do not encode File URI slashes in Preview/Shared Schedules

### DIFF
--- a/src/rise-image.js
+++ b/src/rise-image.js
@@ -402,7 +402,7 @@ class RiseImage extends WatchFilesMixin( ValidFilesMixin( RiseElement )) {
   _handleStartForPreview() {
     this._validFiles.forEach( file => super.handleFileStatusUpdated({
       filePath: file,
-      fileUrl: RiseImage.STORAGE_PREFIX + encodeURIComponent( file ) + "?_=" +
+      fileUrl: RiseImage.STORAGE_PREFIX + encodeURI( file ) + "?_=" +
         this._timeCreatedFor( file ),
       status: this._previewStatusFor( file )
     }));

--- a/test/integration/rise-image-logo.html
+++ b/test/integration/rise-image-logo.html
@@ -241,7 +241,7 @@
       test('it should render image with a cache bumper parameter', () => {
         element.dispatchEvent( new CustomEvent( "start" ) );
 
-        assert.equal(element.$.image.src, "https://storage.googleapis.com/risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013%2Flogo.png?_=");
+        assert.equal(element.$.image.src, "https://storage.googleapis.com/risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/logo.png?_=");
       });
 
     });

--- a/test/integration/rise-image-multiple.html
+++ b/test/integration/rise-image-multiple.html
@@ -337,21 +337,21 @@
       test('it should render first image', () => {
         element.dispatchEvent( new CustomEvent( "start" ) );
 
-        assert.equal(element.$.image.src, "https://storage.googleapis.com/risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f%2Frise-image-demo%2Fcanadiens_logo.gif?_=");
+        assert.equal(element.$.image.src, "https://storage.googleapis.com/risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f/rise-image-demo/canadiens_logo.gif?_=");
       });
 
       test('it should start transition timer for two images and show each for 5 seconds', () => {
         element.dispatchEvent( new CustomEvent( "start" ) );
 
-        assert.equal(element.$.image.src, "https://storage.googleapis.com/risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f%2Frise-image-demo%2Fcanadiens_logo.gif?_=");
+        assert.equal(element.$.image.src, "https://storage.googleapis.com/risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f/rise-image-demo/canadiens_logo.gif?_=");
 
         clock.tick( 5000 );
 
-        assert.equal(element.$.image.src, "https://storage.googleapis.com/risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f%2Frise-image-demo%2Fblue-jays-logo.jpg?_=");
+        assert.equal(element.$.image.src, "https://storage.googleapis.com/risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f/rise-image-demo/blue-jays-logo.jpg?_=");
 
         clock.tick( 5000 );
 
-        assert.equal(element.$.image.src, "https://storage.googleapis.com/risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f%2Frise-image-demo%2Fraptors_logo.png?_=");
+        assert.equal(element.$.image.src, "https://storage.googleapis.com/risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f/rise-image-demo/raptors_logo.png?_=");
       });
 
       test('it should transition all three images', () => {
@@ -360,11 +360,11 @@
         // emulate first two images cycle and first two images shown again in the following cycle
         clock.tick( 20000 );
 
-        assert.equal(element.$.image.src, "https://storage.googleapis.com/risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f%2Frise-image-demo%2Fblue-jays-logo.jpg?_=");
+        assert.equal(element.$.image.src, "https://storage.googleapis.com/risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f/rise-image-demo/blue-jays-logo.jpg?_=");
 
         clock.tick( 5000 );
 
-        assert.equal(element.$.image.src, "https://storage.googleapis.com/risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f%2Frise-image-demo%2Fraptors_logo.png?_=");
+        assert.equal(element.$.image.src, "https://storage.googleapis.com/risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f/rise-image-demo/raptors_logo.png?_=");
       });
 
     });

--- a/test/integration/rise-image-single.html
+++ b/test/integration/rise-image-single.html
@@ -229,7 +229,13 @@
       test('it should render image with a cache bumper parameter', () => {
         element.dispatchEvent( new CustomEvent( "start" ) );
 
-        assert.equal(element.$.image.src, "https://storage.googleapis.com/risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013%2Flogo.png?_=");
+        assert.equal(element.$.image.src, "https://storage.googleapis.com/risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/logo.png?_=");
+      });
+
+      test('it should not encode image url slashes', () => {
+        element.dispatchEvent( new CustomEvent( "start" ) );
+
+        assert.notEqual(element.$.image.src, "https://storage.googleapis.com/risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013%2Flogo.png?_=");
       });
 
     });

--- a/test/unit/rise-image.html
+++ b/test/unit/rise-image.html
@@ -272,7 +272,7 @@
 
             assert.isTrue( element.handleFileStatusUpdated.calledWith({
               filePath: "risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/logo.png",
-              fileUrl: "https://storage.googleapis.com/risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013%2Flogo.png?_=",
+              fileUrl: "https://storage.googleapis.com/risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/logo.png?_=",
               status: "current"
             } ));
           } );
@@ -283,19 +283,19 @@
 
             assert.deepEqual( element.__proto__.__proto__.handleFileStatusUpdated.args[0][0], {
               filePath: "risemedialibrary-abc123/test1.png",
-              fileUrl: "https://storage.googleapis.com/risemedialibrary-abc123%2Ftest1.png?_=",
+              fileUrl: "https://storage.googleapis.com/risemedialibrary-abc123/test1.png?_=",
               status: "current"
             } );
 
             assert.deepEqual( element.__proto__.__proto__.handleFileStatusUpdated.args[1][0], {
               filePath: "risemedialibrary-abc123/test2.png",
-              fileUrl: "https://storage.googleapis.com/risemedialibrary-abc123%2Ftest2.png?_=",
+              fileUrl: "https://storage.googleapis.com/risemedialibrary-abc123/test2.png?_=",
               status: "current"
             } );
 
             assert.deepEqual( element.__proto__.__proto__.handleFileStatusUpdated.args[2][0], {
               filePath: "risemedialibrary-abc123/test3.png",
-              fileUrl: "https://storage.googleapis.com/risemedialibrary-abc123%2Ftest3.png?_=",
+              fileUrl: "https://storage.googleapis.com/risemedialibrary-abc123/test3.png?_=",
               status: "current"
             } );
           } );
@@ -310,7 +310,7 @@
 
             assert.isTrue( element.__proto__.__proto__.handleFileStatusUpdated.calledWith({
               filePath: "risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/logo.png",
-              fileUrl: "https://storage.googleapis.com/risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013%2Flogo.png?_=123",
+              fileUrl: "https://storage.googleapis.com/risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/logo.png?_=123",
               status: "current"
             } ));
           } );


### PR DESCRIPTION
## Description
Changed `encodeURIComponent` to `encodeURI` as it does not encode slashes.

## Motivation and Context
Reduce GCS requests. When a Storage image was located in a subfolder,  `/` was being encoded to %2F and GCS was generating a 301 Redirect request to point to the non encoded version, causing an additional request for every image loaded.

Sample output of the problem:
<img width="1007" alt="Screen Shot 2020-05-12 at 5 13 52 PM" src="https://user-images.githubusercontent.com/7738553/81740886-0c32e280-9474-11ea-9f41-6adb55b92de0.png">

## How Has This Been Tested?
This is only triggered for Template Preview/Shared Schedules. Tested with Charles Proxy for both cases.
Validation:
<img width="862" alt="Screen Shot 2020-05-12 at 5 15 57 PM" src="https://user-images.githubusercontent.com/7738553/81741047-4b613380-9474-11ea-8aa6-3f155d32e59f.png">

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
