### PR TITLE
Add cacheApi initialization in RiseImage component and ensure it works

### DIFF
--- a/src/rise-image.js
+++ b/src/rise-image.js
@@ -112,6 +112,11 @@ class RiseImage extends WatchFilesMixin( ValidFilesMixin( base )) {
 
     this.addEventListener( "rise-presentation-play", () => this._reset());
     this.addEventListener( "rise-presentation-stop", () => this._stop());
+
+    super.initCache({
+      name: `${this.tagName.toLowerCase()}_v${version.charAt(0)}`,
+      expiry: 1000 * 60 * 60 * 24 * 7
+    });
   }
 
   _configureImageEventListeners() {


### PR DESCRIPTION
## Description
Added cacheAPI initialization and expired cache purge in rise-image component.

## Motivation and Context
To initiate cacheAPI, for later images caching.

## How Has This Been Tested?
In template preview with mapped local rise-image.js file. I have checked cache storage and found there corresponding cache.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
