### PR TITLE
Setup rendering image for preview

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -779,7 +779,7 @@
       "integrity": "sha512-dGmKLDdT3Gdl7fBUe8XK+gAtGmzy5Fn0XkkWQuYxGIgWVPPse2CxFA5mtrlD0TOHaHjEUqkWNyP1XdHoJES/4A==",
       "requires": {
         "anymatch": "~3.1.1",
-        "braces": "~3.0.2",
+        "braces": "^2.3.1",
         "fsevents": "~2.1.1",
         "glob-parent": "~5.1.0",
         "is-binary-path": "~2.1.0",
@@ -789,12 +789,7 @@
       },
       "dependencies": {
         "braces": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-          "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
-          "requires": {
-            "fill-range": "^7.0.1"
-          }
+          "version": "^2.3.1"
         }
       }
     },
@@ -913,8 +908,13 @@
         "js-yaml": "^3.13.1",
         "lcov-parse": "^1.0.0",
         "log-driver": "^1.2.7",
-        "minimist": "^1.2.5",
+        "minimist": "^1.2.3",
         "request": "^2.88.2"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "^1.2.3"
+        }
       }
     },
     "cross-spawn": {
@@ -1477,13 +1477,16 @@
       "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.6.tgz",
       "integrity": "sha512-1f2BACcBfiwAfStCKZNrUCgqNZkGsAT7UM3kkYtXuLo0KnaVfjKOyf7PRzB6++aK9STyT1Pd2ZCPe3EGOXleXA==",
       "requires": {
-        "minimist": "^1.2.5",
+        "minimist": "^1.2.3",
         "neo-async": "^2.6.0",
         "source-map": "^0.6.1",
         "uglify-js": "^3.1.4",
         "wordwrap": "^1.0.0"
       },
       "dependencies": {
+        "minimist": {
+          "version": "^1.2.3"
+        },
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -1973,7 +1976,12 @@
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.3.tgz",
       "integrity": "sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==",
       "requires": {
-        "minimist": "^1.2.5"
+        "minimist": "^1.2.3"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "^1.2.3"
+        }
       }
     },
     "jsprim": {
@@ -2105,16 +2113,19 @@
       }
     },
     "minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+      "version": "^1.2.3"
     },
     "mkdirp": {
       "version": "0.5.5",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
       "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
       "requires": {
-        "minimist": "^1.2.5"
+        "minimist": "^1.2.3"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "^1.2.3"
+        }
       }
     },
     "mocha": {
@@ -3012,21 +3023,19 @@
       "integrity": "sha512-SYbXgY64PT+4GAL2ocI3HwPa4Q4TBKm0cwAVeKOt/Aoc0gSpNRjJX8w0pA1LMKZ3LBmd8pYBqApFNQLII9kavA==",
       "requires": {
         "arrify": "^1.0.1",
-        "micromatch": "^2.3.11",
+        "micromatch": "~4.0.2",
         "object-assign": "^4.1.0",
         "read-pkg-up": "^1.0.1",
         "require-main-filename": "^1.0.1"
       },
       "dependencies": {
         "braces": {
-          "version": "1.8.5",
-          "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
-          "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
           "requires": {
             "expand-range": "^1.8.1",
             "preserve": "^0.2.0",
             "repeat-element": "^1.1.2"
-          }
+          },
+          "version": "^2.3.1"
         },
         "is-extglob": {
           "version": "1.0.0",
@@ -3042,24 +3051,7 @@
           }
         },
         "micromatch": {
-          "version": "2.3.11",
-          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
-          "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
-          "requires": {
-            "arr-diff": "^2.0.0",
-            "array-unique": "^0.2.1",
-            "braces": "^1.8.2",
-            "expand-brackets": "^0.1.4",
-            "extglob": "^0.3.1",
-            "filename-regex": "^2.0.0",
-            "is-extglob": "^1.0.0",
-            "is-glob": "^2.0.1",
-            "kind-of": "^3.0.2",
-            "normalize-path": "^2.0.1",
-            "object.omit": "^2.0.0",
-            "parse-glob": "^3.0.4",
-            "regex-cache": "^0.4.2"
-          }
+          "version": "~4.0.2"
         },
         "normalize-path": {
           "version": "2.1.1",

--- a/src/rise-image.js
+++ b/src/rise-image.js
@@ -240,6 +240,16 @@ class RiseImage extends WatchFilesMixin( ValidFilesMixin( base )) {
     });
   }
 
+  _renderImageForPreview( fileUrl ) {
+    // TODO: call super.getFile( fileUrl )
+    // TODO: ensure a catch to handle error
+    // TODO: on successfull resolve, set the src on image instance below with the provided objectUrl
+    // TODO: revoke the previously stored objectUrl and now store reference to latest objectUrl
+
+    // for now set src to the fileUrl until the above functionality is in place
+    this.$.image.src = fileUrl;
+  }
+
   _renderImage( filePath, fileUrl ) {
     if ( this.responsive ) {
       this.$.image.updateStyles({ "--iron-image-width": "100%", "width": "100%", "height": "auto", "display": "inline-block" });
@@ -249,6 +259,10 @@ class RiseImage extends WatchFilesMixin( ValidFilesMixin( base )) {
       this.$.image.height = isNaN( this.height ) ? parseInt( this.height, 10 ) : this.height;
       this.$.image.sizing = this.sizing;
       this.$.image.position = this.position;
+    }
+
+    if ( RisePlayerConfiguration.isPreview() ) {
+      return this._renderImageForPreview( fileUrl );
     }
 
     if ( super.getStorageFileFormat( filePath ) === "svg" ) {
@@ -360,7 +374,6 @@ class RiseImage extends WatchFilesMixin( ValidFilesMixin( base )) {
       this._validFiles = validFiles;
 
       if ( RisePlayerConfiguration.isPreview()) {
-        super.getFile( "test" );
         return this._handleStartForPreview();
       }
 
@@ -452,9 +465,13 @@ class RiseImage extends WatchFilesMixin( ValidFilesMixin( base )) {
   }
 
   watchedFileAddedCallback() {
+    if ( RisePlayerConfiguration.isPreview() && this.managedFiles.length !== this._validFiles.length ) {
+      // For preview we wait until watchFilesMixin is managing full list of valid files
+      return;
+    }
+
     this._configureShowingImages();
   }
-
 
   watchedFileDeletedCallback( details ) {
     const { filePath } = details;

--- a/test/unit/rise-image.html
+++ b/test/unit/rise-image.html
@@ -53,6 +53,8 @@
             error: () => {}
           };
 
+          RisePlayerConfiguration.isPreview = () => false;
+
           element = fixture("test-block");
         });
 
@@ -215,11 +217,14 @@
             sinon.stub(element, "_getDataUrlFromSVGLocalUrl").callsFake(() => {
               return Promise.resolve("dataurl");
             });
+            sinon.stub(element, '_renderImageForPreview');
           } );
 
           teardown( () => {
             element.$.image.updateStyles.restore();
             element._getDataUrlFromSVGLocalUrl.restore();
+            element._renderImageForPreview.restore();
+            RisePlayerConfiguration.isPreview = () => false;
           } );
 
           test( "should ignore width/height/sizing/position and apply responsive styling", () => {
@@ -252,6 +257,14 @@
             element._renderImage( "risemedialibrary-abc123/test.svg", "https://storage.googleapis.com/risemedialibrary-abc123/test.svg" );
 
             assert.isTrue( element._getDataUrlFromSVGLocalUrl.called );
+          } );
+
+          test( "should call _renderImageForPreview() when running in Preview", () => {
+            RisePlayerConfiguration.isPreview = () => true;
+
+            element._renderImage( "risemedialibrary-abc123/test.jpg", "https://storage.googleapis.com/risemedialibrary-abc123/test.jpg" );
+
+            assert.isTrue( element._renderImageForPreview.called );
           } );
         } );
 
@@ -790,6 +803,57 @@
 
             assert.deepEqual( element._filesToRenderList, [] );
             assert.equal( element._clearDisplayedImage.callCount, 1 );
+          });
+        });
+
+        suite( "watchedFileAddedCallback", () => {
+          const sandbox = sinon.createSandbox();
+
+          setup( () => {
+            sandbox.stub(element, '_configureShowingImages');
+          });
+
+          teardown( () => {
+            sandbox.restore();
+            RisePlayerConfiguration.isPreview = () => false;
+          });
+
+          test( "should not call configureShowingImages when running in Preview and full list isn't managed yet", () => {
+            RisePlayerConfiguration.isPreview = () => true;
+
+            element._validFiles = [ "risemedialibrary-abc123/testing/a.jpg", "risemedialibrary-abc123/testing/b.jpg", "risemedialibrary-abc123/testing/c.jpg" ];
+            element.managedFiles = [ {
+              filePath: "risemedialibrary-abc123/testing/a.jpg",
+              fileUrl: "https://storage.googleapis.com/risemedialibrary-abc123/testing/a.jpg",
+              order: 0
+            } ]
+
+            element.watchedFileAddedCallback();
+
+            assert.isFalse( element._configureShowingImages.called );
+          });
+
+          test( "should call configureShowingImages when running in Preview and full list is now managed", () => {
+            RisePlayerConfiguration.isPreview = () => true;
+
+            element._validFiles = [ "risemedialibrary-abc123/testing/a.jpg", "risemedialibrary-abc123/testing/b.jpg", "risemedialibrary-abc123/testing/c.jpg" ];
+            element.managedFiles = [ {
+              filePath: "risemedialibrary-abc123/testing/a.jpg",
+              fileUrl: "https://storage.googleapis.com/risemedialibrary-abc123/testing/a.jpg",
+              order: 0
+            }, {
+                filePath: "risemedialibrary-abc123/testing/b.jpg",
+                fileUrl: "https://storage.googleapis.com/risemedialibrary-abc123/testing/b.jpg",
+                order: 1
+            }, {
+              filePath: "risemedialibrary-abc123/testing/c.jpg",
+              fileUrl: "https://storage.googleapis.com/risemedialibrary-abc123/testing/c.jpg",
+              order: 2
+            } ]
+
+            element.watchedFileAddedCallback();
+
+            assert.isTrue( element._configureShowingImages.called );
           });
         });
 


### PR DESCRIPTION
## Description
Establish the logic and flow for setting up a new function to render images when running Preview that will leverage StoreFilesMixin for caching.

**Reminder**
Component will deploy to version 2 on GCS which is not the production version being used by templates. No impact to users when merging these changes.

## Motivation and Context
Small incremental changes to have image component cache and display images in Editor Preview and Shared Schedules

## How Has This Been Tested?
Tested with template in apps https://apps.risevision.com/templates/edit/e47cac53-d4d2-4d0c-90db-4a6ee7b12c53/?cid=f114ad26-949d-44b4-87e9-8528afc76ce4 using Charles to map to local file of component.

Added unit tests

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
n/a
