### PR TITLE
Rise image checks what is returned from getFile and sets image src to…

### DIFF
--- a/src/rise-image.js
+++ b/src/rise-image.js
@@ -240,8 +240,8 @@ class RiseImage extends WatchFilesMixin( ValidFilesMixin( base )) {
     });
   }
 
-  _renderImageForPreview( filePath ) {
-    super.getFile( this._getFileUrl(filePath))
+  _renderImageForPreview( fileUrl ) {
+    super.getFile( fileUrl )
       .then( objectUrl => {
         if ( typeof objectUrl === "string" ) {
           this.$.image.src = objectUrl;
@@ -267,7 +267,7 @@ class RiseImage extends WatchFilesMixin( ValidFilesMixin( base )) {
     }
 
     if ( RisePlayerConfiguration.isPreview() ) {
-      return this._renderImageForPreview( filePath );
+      return this._renderImageForPreview( fileUrl );
     }
 
     if ( super.getStorageFileFormat( filePath ) === "svg" ) {
@@ -335,6 +335,7 @@ class RiseImage extends WatchFilesMixin( ValidFilesMixin( base )) {
 
   _configureShowingImages() {
     this._filesToRenderList = this.managedFiles
+      .slice( 0 )
       .filter( f => this._validFiles.includes( f.filePath ));
 
     this._transitionIndex = 0;

--- a/src/rise-image.js
+++ b/src/rise-image.js
@@ -240,14 +240,19 @@ class RiseImage extends WatchFilesMixin( ValidFilesMixin( base )) {
     });
   }
 
-  _renderImageForPreview( fileUrl ) {
-    // TODO: call super.getFile( fileUrl )
-    // TODO: ensure a catch to handle error
-    // TODO: on successfull resolve, set the src on image instance below with the provided objectUrl
+  _renderImageForPreview( filePath ) {
+    super.getFile( this._getFileUrl(filePath))
+      .then( objectUrl => {
+        if ( typeof objectUrl === "string" ) {
+          this.$.image.src = objectUrl;
+        } else {
+          throw new Error( "Invalid file url!" );
+        }
+      }).catch( error => {
+        // TODO: handle error
+        console.error( error );
+      })
     // TODO: revoke the previously stored objectUrl and now store reference to latest objectUrl
-
-    // for now set src to the fileUrl until the above functionality is in place
-    this.$.image.src = fileUrl;
   }
 
   _renderImage( filePath, fileUrl ) {
@@ -262,7 +267,7 @@ class RiseImage extends WatchFilesMixin( ValidFilesMixin( base )) {
     }
 
     if ( RisePlayerConfiguration.isPreview() ) {
-      return this._renderImageForPreview( fileUrl );
+      return this._renderImageForPreview( filePath );
     }
 
     if ( super.getStorageFileFormat( filePath ) === "svg" ) {
@@ -330,7 +335,6 @@ class RiseImage extends WatchFilesMixin( ValidFilesMixin( base )) {
 
   _configureShowingImages() {
     this._filesToRenderList = this.managedFiles
-      .slice( 0 )
       .filter( f => this._validFiles.includes( f.filePath ));
 
     this._transitionIndex = 0;

--- a/test/integration/rise-image-logo.html
+++ b/test/integration/rise-image-logo.html
@@ -232,16 +232,23 @@
     suite('running on preview or directly in browser', () => {
       setup(() => {
         RisePlayerConfiguration.isPreview = () => true;
+
+        sinon.stub(element.__proto__.__proto__.__proto__, "getFile").resolves("test object url");
       });
 
       teardown(() => {
         RisePlayerConfiguration.isPreview = () => false;
       });
 
-      test('it should render image with a cache bumper parameter', () => {
+      test('it should render image with an object url', (done) => {
         element.dispatchEvent( new CustomEvent( "start" ) );
 
-        assert.equal(element.$.image.src, "https://storage.googleapis.com/risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/logo.png?_=");
+        // delay to account for promise resolve
+        setTimeout(() => {
+          assert.isTrue(element.getFile.calledWith("https://storage.googleapis.com/risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/logo.png?_="));
+          assert.equal(element.$.image.src, "test object url");
+          done();
+        }, 100);
       });
 
     });

--- a/test/integration/rise-image-multiple.html
+++ b/test/integration/rise-image-multiple.html
@@ -328,43 +328,51 @@
     suite('running on preview or directly in browser', () => {
       setup(() => {
         RisePlayerConfiguration.isPreview = () => true;
+
+        sinon.stub(element.__proto__.__proto__.__proto__, "getFile").resolves("test object url");
       });
 
       teardown(() => {
         RisePlayerConfiguration.isPreview = () => false;
+        element.__proto__.__proto__.__proto__.getFile.restore();
       });
 
-      test('it should render first image', () => {
+      test('it should render first image', (done) => {
+        clock.restore();
+
         element.dispatchEvent( new CustomEvent( "start" ) );
 
-        assert.equal(element.$.image.src, "https://storage.googleapis.com/risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f/rise-image-demo/canadiens_logo.gif?_=");
+        // delay to account for promise resolve
+        setTimeout(() => {
+          assert.isTrue(element.getFile.calledWith("https://storage.googleapis.com/risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f/rise-image-demo/canadiens_logo.gif?_="));
+          assert.equal(element.$.image.src, "test object url");
+          done();
+        }, 100);
+
       });
 
-      test('it should start transition timer for two images and show each for 5 seconds', () => {
+      test('it should start transitioning to show all 3 images for mocked duration', (done) => {
+        clock.restore();
+
+        sinon.stub(element, "_startTransitionTimer").callsFake(() => {
+          setTimeout(() => {
+            element._onShowImageComplete();
+          }, 200);
+        });
+
         element.dispatchEvent( new CustomEvent( "start" ) );
 
-        assert.equal(element.$.image.src, "https://storage.googleapis.com/risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f/rise-image-demo/canadiens_logo.gif?_=");
+        // delay to account for promise resolve
+        setTimeout(() => {
+          assert.equal(element.getFile.args[0][0], "https://storage.googleapis.com/risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f/rise-image-demo/canadiens_logo.gif?_=");
+          assert.equal(element.getFile.args[1][0], "https://storage.googleapis.com/risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f/rise-image-demo/blue-jays-logo.jpg?_=");
+          assert.equal(element.getFile.args[2][0], "https://storage.googleapis.com/risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f/rise-image-demo/raptors_logo.png?_=");
+          assert.equal(element.$.image.src, "test object url");
 
-        clock.tick( 5000 );
+          element._startTransitionTimer.restore();
 
-        assert.equal(element.$.image.src, "https://storage.googleapis.com/risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f/rise-image-demo/blue-jays-logo.jpg?_=");
-
-        clock.tick( 5000 );
-
-        assert.equal(element.$.image.src, "https://storage.googleapis.com/risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f/rise-image-demo/raptors_logo.png?_=");
-      });
-
-      test('it should transition all three images', () => {
-        element.dispatchEvent( new CustomEvent( "start" ) );
-
-        // emulate first two images cycle and first two images shown again in the following cycle
-        clock.tick( 20000 );
-
-        assert.equal(element.$.image.src, "https://storage.googleapis.com/risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f/rise-image-demo/blue-jays-logo.jpg?_=");
-
-        clock.tick( 5000 );
-
-        assert.equal(element.$.image.src, "https://storage.googleapis.com/risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f/rise-image-demo/raptors_logo.png?_=");
+          done();
+        }, 600);
       });
 
     });

--- a/test/integration/rise-image-single.html
+++ b/test/integration/rise-image-single.html
@@ -220,16 +220,23 @@
     suite('running on preview or directly in browser', () => {
       setup(() => {
         RisePlayerConfiguration.isPreview = () => true;
+
+        sinon.stub(element.__proto__.__proto__.__proto__, "getFile").resolves("test object url");
       });
 
       teardown(() => {
         RisePlayerConfiguration.isPreview = () => false;
       });
 
-      test('it should render image with a cache bumper parameter', () => {
+      test('it should render image with an object url', (done) => {
         element.dispatchEvent( new CustomEvent( "start" ) );
 
-        assert.equal(element.$.image.src, "https://storage.googleapis.com/risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/logo.png?_=");
+        // delay to account for promise resolve
+        setTimeout(() => {
+          assert.isTrue(element.getFile.calledWith("https://storage.googleapis.com/risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/logo.png?_="));
+          assert.equal(element.$.image.src, "test object url");
+          done();
+        }, 100);
       });
 
     });

--- a/test/unit/rise-image.html
+++ b/test/unit/rise-image.html
@@ -268,6 +268,31 @@
           } );
         } );
 
+        suite( "_renderImageForPreview", () => {
+          setup( () => {
+            sinon.stub(element.__proto__.__proto__.__proto__, "getFile").resolves("test object url");
+          } );
+
+          teardown( () => {
+            element.__proto__.__proto__.__proto__.getFile.restore();
+          } );
+
+          test( "should make getFile() call of StoreFilesMixin with correct file url", () => {
+            element._renderImageForPreview("https://storage.googleapis.com/risemedialibrary-abc123/test1.png?_=");
+
+            assert.isTrue(element.getFile.calledWith("https://storage.googleapis.com/risemedialibrary-abc123/test1.png?_="));
+          } );
+
+          test( "should set src of image with object url", (done) => {
+            element._renderImageForPreview("https://storage.googleapis.com/risemedialibrary-abc123/test1.png?_=");
+
+            setTimeout(() => {
+              assert.equal(element.$.image.src, "test object url");
+              done();
+            }, 100);
+          } );
+        } );
+
         suite( "_getFileUrl", () => {
 
           test( "should encode file path", (done) => {


### PR DESCRIPTION
## Description
Rise image checks what is returned from getFile and sets image src to returned value if value is objectUrl. THIS IS WORK IN PROGRESS - error handling is not finished!

## Motivation and Context
We need to show file in template.

## How Has This Been Tested?
Manually in APPS mapping to local file

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
