### PR TITLE
Ensure to revoke object url when no longer needed

### DIFF
--- a/src/rise-image.js
+++ b/src/rise-image.js
@@ -141,13 +141,21 @@ class RiseImage extends WatchFilesMixin( ValidFilesMixin( base )) {
         storage: super.getStorageData( filePath, fileUrl )
       });
       this._sendImageEvent( RiseImage.EVENT_IMAGE_ERROR, { filePath, errorMessage: "image load failed" });
+      this._revokeObjectUrl();
     });
 
     this.$.image.addEventListener( "loaded-changed", event => {
       if ( event.detail.value === true ) {
         super._setUptimeError( false );
+        this._revokeObjectUrl();
       }
     });
+  }
+
+  _revokeObjectUrl() {
+    if ( RisePlayerConfiguration.isPreview() && this.$.image.src ) {
+      URL.revokeObjectURL( this.$.image.src );
+    }
   }
 
   _isLogoChanged() {

--- a/test/unit/rise-image.html
+++ b/test/unit/rise-image.html
@@ -882,6 +882,62 @@
           });
         });
 
+        suite( "_revokeObjectUrl", () => {
+          setup( () => {
+            sinon.stub(URL, "revokeObjectURL");
+            RisePlayerConfiguration.isPreview = () => true;
+            element.$.image.src = "test object url";
+          } );
+
+          teardown( () => {
+            URL.revokeObjectURL.restore();
+            RisePlayerConfiguration.isPreview = () => false;
+          } );
+
+          test( "should revoke object url", () => {
+            element._revokeObjectUrl();
+
+            assert.isTrue(URL.revokeObjectURL.called);
+          } );
+
+          test( "should not execute revoke if src is empty", () => {
+            element.$.image.src = "";
+            element._revokeObjectUrl();
+
+            assert.isFalse(URL.revokeObjectURL.called);
+          } );
+
+          test( "should not execute revoke if not running in Preview", () => {
+            RisePlayerConfiguration.isPreview = () => false;
+            element._revokeObjectUrl();
+
+            assert.isFalse(URL.revokeObjectURL.called);
+          } );
+        } );
+
+        suite( "image event listeners", () => {
+          setup( () => {
+            sinon.stub(element, "_revokeObjectUrl");
+          } );
+
+          teardown( () => {
+            element._revokeObjectUrl.restore();
+          } );
+
+          test("should call _revokeObjectUrl() when image successfully loaded", () => {
+            element.$.image.dispatchEvent( new CustomEvent( "loaded-changed", { detail: { value: true } } ));
+
+            assert.isTrue(element._revokeObjectUrl.called);
+          });
+
+          test("should call _revokeObjectUrl() when image failed to load", () => {
+            element._filesToRenderList = ["test.jpg"];
+            element.$.image.dispatchEvent( new CustomEvent( "error-changed", { detail: { value: true } } ));
+
+            assert.isTrue(element._revokeObjectUrl.called);
+          });
+        } );
+
       });
     </script>
   </body>


### PR DESCRIPTION
## Description
Revoking the provided object url from StoreFilesMixin when the image load has completed. 

## Motivation and Context
This is necessary to enable the Browser to garbage collect the blob object url otherwise it will remain in memory until page is closed. Since we are dynamically creating blob object urls for every image, we must ensure they are always revoked. 

## How Has This Been Tested?
Manually tested on apps with https://apps.risevision.com/templates/edit/5dba9780-d656-4999-b2f1-7ce71dda6f64/?cid=7fa5ee92-7deb-450b-a8d5-e5ed648c575f and Charles to map to local version of component. Validated that the revoke gets called and no script or visual errors occur, component continues to work as expected. 

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
n/a
