### PR TITLE
Remove cachebuster from file url for rendering in preview

### DIFF
--- a/src/rise-image.js
+++ b/src/rise-image.js
@@ -424,16 +424,6 @@ class RiseImage extends WatchFilesMixin( ValidFilesMixin( base )) {
     return entry && entry.exists ? "current" : "deleted";
   }
 
-  _timeCreatedFor( file ) {
-    if ( !this._hasMetadata()) {
-      return "";
-    }
-
-    const entry = this._metadataEntryFor( file );
-
-    return entry && entry[ "time-created" ] ? entry[ "time-created" ] : "";
-  }
-
   _handleStartForPreview() {
     this._validFiles.forEach( file => super.handleFileStatusUpdated({
       filePath: file,
@@ -455,7 +445,7 @@ class RiseImage extends WatchFilesMixin( ValidFilesMixin( base )) {
   }
 
   _getFileUrl( file ) {
-    return RiseImage.STORAGE_PREFIX + this._encodePath( file ) + "?_=" + this._timeCreatedFor( file );
+    return RiseImage.STORAGE_PREFIX + this._encodePath( file );
   }
 
   _encodePath( filePath ) {

--- a/test/integration/rise-image-logo.html
+++ b/test/integration/rise-image-logo.html
@@ -245,7 +245,7 @@
 
         // delay to account for promise resolve
         setTimeout(() => {
-          assert.isTrue(element.getFile.calledWith("https://storage.googleapis.com/risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/logo.png?_="));
+          assert.isTrue(element.getFile.calledWith("https://storage.googleapis.com/risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/logo.png"));
           assert.equal(element.$.image.src, "test object url");
           done();
         }, 100);

--- a/test/integration/rise-image-multiple.html
+++ b/test/integration/rise-image-multiple.html
@@ -344,7 +344,7 @@
 
         // delay to account for promise resolve
         setTimeout(() => {
-          assert.isTrue(element.getFile.calledWith("https://storage.googleapis.com/risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f/rise-image-demo/canadiens_logo.gif?_="));
+          assert.isTrue(element.getFile.calledWith("https://storage.googleapis.com/risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f/rise-image-demo/canadiens_logo.gif"));
           assert.equal(element.$.image.src, "test object url");
           done();
         }, 100);
@@ -364,9 +364,9 @@
 
         // delay to account for promise resolve
         setTimeout(() => {
-          assert.equal(element.getFile.args[0][0], "https://storage.googleapis.com/risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f/rise-image-demo/canadiens_logo.gif?_=");
-          assert.equal(element.getFile.args[1][0], "https://storage.googleapis.com/risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f/rise-image-demo/blue-jays-logo.jpg?_=");
-          assert.equal(element.getFile.args[2][0], "https://storage.googleapis.com/risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f/rise-image-demo/raptors_logo.png?_=");
+          assert.equal(element.getFile.args[0][0], "https://storage.googleapis.com/risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f/rise-image-demo/canadiens_logo.gif");
+          assert.equal(element.getFile.args[1][0], "https://storage.googleapis.com/risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f/rise-image-demo/blue-jays-logo.jpg");
+          assert.equal(element.getFile.args[2][0], "https://storage.googleapis.com/risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f/rise-image-demo/raptors_logo.png");
           assert.equal(element.$.image.src, "test object url");
 
           element._startTransitionTimer.restore();

--- a/test/integration/rise-image-single.html
+++ b/test/integration/rise-image-single.html
@@ -233,7 +233,7 @@
 
         // delay to account for promise resolve
         setTimeout(() => {
-          assert.isTrue(element.getFile.calledWith("https://storage.googleapis.com/risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/logo.png?_="));
+          assert.isTrue(element.getFile.calledWith("https://storage.googleapis.com/risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/logo.png"));
           assert.equal(element.$.image.src, "test object url");
           done();
         }, 100);

--- a/test/unit/rise-image.html
+++ b/test/unit/rise-image.html
@@ -331,7 +331,7 @@
 
             assert.isTrue( element.handleFileStatusUpdated.calledWith({
               filePath: "risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/logo.png",
-              fileUrl: "https://storage.googleapis.com/risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/logo.png?_=",
+              fileUrl: "https://storage.googleapis.com/risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/logo.png",
               status: "current"
             } ));
           } );
@@ -342,19 +342,19 @@
 
             assert.deepEqual( element.__proto__.__proto__.handleFileStatusUpdated.args[0][0], {
               filePath: "risemedialibrary-abc123/test1.png",
-              fileUrl: "https://storage.googleapis.com/risemedialibrary-abc123/test1.png?_=",
+              fileUrl: "https://storage.googleapis.com/risemedialibrary-abc123/test1.png",
               status: "current"
             } );
 
             assert.deepEqual( element.__proto__.__proto__.handleFileStatusUpdated.args[1][0], {
               filePath: "risemedialibrary-abc123/test2.png",
-              fileUrl: "https://storage.googleapis.com/risemedialibrary-abc123/test2.png?_=",
+              fileUrl: "https://storage.googleapis.com/risemedialibrary-abc123/test2.png",
               status: "current"
             } );
 
             assert.deepEqual( element.__proto__.__proto__.handleFileStatusUpdated.args[2][0], {
               filePath: "risemedialibrary-abc123/test3.png",
-              fileUrl: "https://storage.googleapis.com/risemedialibrary-abc123/test3.png?_=",
+              fileUrl: "https://storage.googleapis.com/risemedialibrary-abc123/test3.png",
               status: "current"
             } );
           } );
@@ -369,7 +369,7 @@
 
             assert.isTrue( element.__proto__.__proto__.handleFileStatusUpdated.calledWith({
               filePath: "risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/logo.png",
-              fileUrl: "https://storage.googleapis.com/risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/logo.png?_=123",
+              fileUrl: "https://storage.googleapis.com/risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/logo.png",
               status: "current"
             } ));
           } );


### PR DESCRIPTION
## Description
Remove the cachebuster being appended to file urls when component is running in "preview" 

## Motivation and Context
Previously we were appending this cache buster to use the metadata value of `time-created` that is updated from Attribute Editor when a new version of image was uploaded. This was so the component in editor preview would request the image and not get a browser cached version if the file had changed. 

Now since we are implementing our caching mechanism using Cache API, this is no longer needed as we will be making requests leveraging `etag` value to know if file has changed or not.  

## How Has This Been Tested?
Manually tested in apps presentation using Charles to map to local version of component. Also updated unit tests. 

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
n/a
