### PR TITLE
Construct URLs for preview to use GCS JSON API

### DIFF
--- a/src/rise-image.js
+++ b/src/rise-image.js
@@ -445,17 +445,15 @@ class RiseImage extends WatchFilesMixin( ValidFilesMixin( base )) {
   }
 
   _getFileUrl( file ) {
-    return RiseImage.STORAGE_PREFIX + this._encodePath( file );
+    return `${RiseImage.STORAGE_PREFIX}storage/v1/b/${this._constructPath( file )}`;
   }
 
-  _encodePath( filePath ) {
-    // encode each element of the path separatly
+  _constructPath( filePath ) {
+    const path = filePath.split("risemedialibrary-")[1];
+    const bucket = path.slice(0, path.indexOf("/"));
+    const object = encodeURIComponent(path.slice(path.indexOf("/") + 1));
 
-    let encodedPath = filePath.split("/")
-    .map( pathElement => encodeURIComponent( pathElement ))
-    .join("/");
-
-    return encodedPath;
+    return `risemedialibrary-${bucket}/o/${object}?alt=media`;
   }
 
   watchedFileErrorCallback() {

--- a/test/integration/rise-image-logo.html
+++ b/test/integration/rise-image-logo.html
@@ -245,7 +245,7 @@
 
         // delay to account for promise resolve
         setTimeout(() => {
-          assert.isTrue(element.getFile.calledWith("https://storage.googleapis.com/risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/logo.png"));
+          assert.isTrue(element.getFile.calledWith("https://storage.googleapis.com/storage/v1/b/risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/o/logo.png?alt=media"));
           assert.equal(element.$.image.src, "test object url");
           done();
         }, 100);

--- a/test/integration/rise-image-multiple.html
+++ b/test/integration/rise-image-multiple.html
@@ -344,7 +344,7 @@
 
         // delay to account for promise resolve
         setTimeout(() => {
-          assert.isTrue(element.getFile.calledWith("https://storage.googleapis.com/risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f/rise-image-demo/canadiens_logo.gif"));
+          assert.isTrue(element.getFile.calledWith("https://storage.googleapis.com/storage/v1/b/risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f/o/rise-image-demo%2Fcanadiens_logo.gif?alt=media"));
           assert.equal(element.$.image.src, "test object url");
           done();
         }, 100);
@@ -364,9 +364,9 @@
 
         // delay to account for promise resolve
         setTimeout(() => {
-          assert.equal(element.getFile.args[0][0], "https://storage.googleapis.com/risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f/rise-image-demo/canadiens_logo.gif");
-          assert.equal(element.getFile.args[1][0], "https://storage.googleapis.com/risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f/rise-image-demo/blue-jays-logo.jpg");
-          assert.equal(element.getFile.args[2][0], "https://storage.googleapis.com/risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f/rise-image-demo/raptors_logo.png");
+          assert.equal(element.getFile.args[0][0], "https://storage.googleapis.com/storage/v1/b/risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f/o/rise-image-demo%2Fcanadiens_logo.gif?alt=media");
+          assert.equal(element.getFile.args[1][0], "https://storage.googleapis.com/storage/v1/b/risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f/o/rise-image-demo%2Fblue-jays-logo.jpg?alt=media");
+          assert.equal(element.getFile.args[2][0], "https://storage.googleapis.com/storage/v1/b/risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f/o/rise-image-demo%2Fraptors_logo.png?alt=media");
           assert.equal(element.$.image.src, "test object url");
 
           element._startTransitionTimer.restore();

--- a/test/integration/rise-image-single.html
+++ b/test/integration/rise-image-single.html
@@ -233,7 +233,7 @@
 
         // delay to account for promise resolve
         setTimeout(() => {
-          assert.isTrue(element.getFile.calledWith("https://storage.googleapis.com/risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/logo.png"));
+          assert.isTrue(element.getFile.calledWith("https://storage.googleapis.com/storage/v1/b/risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/o/logo.png?alt=media"));
           assert.equal(element.$.image.src, "test object url");
           done();
         }, 100);

--- a/test/unit/rise-image.html
+++ b/test/unit/rise-image.html
@@ -295,21 +295,21 @@
 
         suite( "_getFileUrl", () => {
 
-          test( "should encode file path", (done) => {
+          test( "should return correctly constructed url for GCS JSON API", (done) => {
             let filePath = "risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/unit-test-do-not-delete/Ü-+ test%20encoding ([!@?,#$])=1+2-A&%.jpg";
             let fileUrl = element._getFileUrl( filePath );
 
-            assert.isTrue(fileUrl.indexOf("/risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/") > 0, "forward slash in file path is not encoded" );
+            assert.equal(fileUrl, "https://storage.googleapis.com/storage/v1/b/risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/o/unit-test-do-not-delete%2FU%CC%88-%2B%20test%2520encoding%20(%5B!%40%3F%2C%23%24%5D)%3D1%2B2-A%26%25.jpg?alt=media");
 
             fetch(fileUrl)
-            .then( (res) => {
+              .then( (res) => {
                 assert.isTrue(res.status === 200);
                 done();
-            } )
-            .catch( (error) => {
-              assert.fail( error );
-              done();
-            } );
+              } )
+              .catch( (error) => {
+                assert.fail( error );
+                done();
+              } );
           } );
 
         } );
@@ -331,7 +331,7 @@
 
             assert.isTrue( element.handleFileStatusUpdated.calledWith({
               filePath: "risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/logo.png",
-              fileUrl: "https://storage.googleapis.com/risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/logo.png",
+              fileUrl: "https://storage.googleapis.com/storage/v1/b/risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/o/logo.png?alt=media",
               status: "current"
             } ));
           } );
@@ -342,19 +342,19 @@
 
             assert.deepEqual( element.__proto__.__proto__.handleFileStatusUpdated.args[0][0], {
               filePath: "risemedialibrary-abc123/test1.png",
-              fileUrl: "https://storage.googleapis.com/risemedialibrary-abc123/test1.png",
+              fileUrl: "https://storage.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/test1.png?alt=media",
               status: "current"
             } );
 
             assert.deepEqual( element.__proto__.__proto__.handleFileStatusUpdated.args[1][0], {
               filePath: "risemedialibrary-abc123/test2.png",
-              fileUrl: "https://storage.googleapis.com/risemedialibrary-abc123/test2.png",
+              fileUrl: "https://storage.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/test2.png?alt=media",
               status: "current"
             } );
 
             assert.deepEqual( element.__proto__.__proto__.handleFileStatusUpdated.args[2][0], {
               filePath: "risemedialibrary-abc123/test3.png",
-              fileUrl: "https://storage.googleapis.com/risemedialibrary-abc123/test3.png",
+              fileUrl: "https://storage.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/test3.png?alt=media",
               status: "current"
             } );
           } );
@@ -369,7 +369,7 @@
 
             assert.isTrue( element.__proto__.__proto__.handleFileStatusUpdated.calledWith({
               filePath: "risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/logo.png",
-              fileUrl: "https://storage.googleapis.com/risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/logo.png",
+              fileUrl: "https://storage.googleapis.com/storage/v1/b/risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/o/logo.png?alt=media",
               status: "current"
             } ));
           } );


### PR DESCRIPTION
## Description
When running in Preview, construct urls for fetching files (via StoreFilesMixin) to apply GCS JSON API formatting. 

## Motivation and Context
Previously we were formatting to adhere to GCS XML API endpoint:

> XML API endpoints accept CORS requests based on the CORS configuration on the target bucket.

When we tested configuring CORS directly on GCS storage buckets we experienced inconsistent results. The browser was throwing a CORS policy error when the fetch had included a `If-None-Match` header and there was no difference in `etag` value so server responds with 304 status. The server was not consistently responding with `access-control-allow-origin` header in the response. We opened a ticket with Google and the case is ongoing.

As a workaround, 

> JSON API endpoints allow CORS requests, regardless of CORS configuration on the target bucket.

Hence, we are now going to leverage JSON API as we confirmed we receive all necessary response headers. 

## How Has This Been Tested?
Unit tests and directly in browser. 

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
n/a
