### PR TITLE
Revert constructing URLs for preview to use GCS JSON API

### DIFF
--- a/src/rise-image.js
+++ b/src/rise-image.js
@@ -445,15 +445,16 @@ class RiseImage extends WatchFilesMixin( ValidFilesMixin( base )) {
   }
 
   _getFileUrl( file ) {
-    return `${RiseImage.STORAGE_PREFIX}storage/v1/b/${this._constructPath( file )}`;
+    return RiseImage.STORAGE_PREFIX + this._encodePath( file );
   }
 
-  _constructPath( filePath ) {
-    const path = filePath.split("risemedialibrary-")[1];
-    const bucket = path.slice(0, path.indexOf("/"));
-    const object = encodeURIComponent(path.slice(path.indexOf("/") + 1));
+  _encodePath( filePath ) {
+    // encode each element of the path separatly
+    let encodedPath = filePath.split("/")
+      .map( pathElement => encodeURIComponent( pathElement ))
+      .join("/");
 
-    return `risemedialibrary-${bucket}/o/${object}?alt=media`;
+    return encodedPath;
   }
 
   watchedFileErrorCallback() {

--- a/test/integration/rise-image-logo.html
+++ b/test/integration/rise-image-logo.html
@@ -245,7 +245,7 @@
 
         // delay to account for promise resolve
         setTimeout(() => {
-          assert.isTrue(element.getFile.calledWith("https://storage.googleapis.com/storage/v1/b/risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/o/logo.png?alt=media"));
+          assert.isTrue(element.getFile.calledWith("https://storage.googleapis.com/risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/logo.png"));
           assert.equal(element.$.image.src, "test object url");
           done();
         }, 100);

--- a/test/integration/rise-image-multiple.html
+++ b/test/integration/rise-image-multiple.html
@@ -344,7 +344,7 @@
 
         // delay to account for promise resolve
         setTimeout(() => {
-          assert.isTrue(element.getFile.calledWith("https://storage.googleapis.com/storage/v1/b/risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f/o/rise-image-demo%2Fcanadiens_logo.gif?alt=media"));
+          assert.isTrue(element.getFile.calledWith("https://storage.googleapis.com/risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f/rise-image-demo/canadiens_logo.gif"));
           assert.equal(element.$.image.src, "test object url");
           done();
         }, 100);
@@ -364,9 +364,9 @@
 
         // delay to account for promise resolve
         setTimeout(() => {
-          assert.equal(element.getFile.args[0][0], "https://storage.googleapis.com/storage/v1/b/risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f/o/rise-image-demo%2Fcanadiens_logo.gif?alt=media");
-          assert.equal(element.getFile.args[1][0], "https://storage.googleapis.com/storage/v1/b/risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f/o/rise-image-demo%2Fblue-jays-logo.jpg?alt=media");
-          assert.equal(element.getFile.args[2][0], "https://storage.googleapis.com/storage/v1/b/risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f/o/rise-image-demo%2Fraptors_logo.png?alt=media");
+          assert.equal(element.getFile.args[0][0], "https://storage.googleapis.com/risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f/rise-image-demo/canadiens_logo.gif");
+          assert.equal(element.getFile.args[1][0], "https://storage.googleapis.com/risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f/rise-image-demo/blue-jays-logo.jpg");
+          assert.equal(element.getFile.args[2][0], "https://storage.googleapis.com/risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f/rise-image-demo/raptors_logo.png");
           assert.equal(element.$.image.src, "test object url");
 
           element._startTransitionTimer.restore();

--- a/test/integration/rise-image-single.html
+++ b/test/integration/rise-image-single.html
@@ -233,7 +233,7 @@
 
         // delay to account for promise resolve
         setTimeout(() => {
-          assert.isTrue(element.getFile.calledWith("https://storage.googleapis.com/storage/v1/b/risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/o/logo.png?alt=media"));
+          assert.isTrue(element.getFile.calledWith("https://storage.googleapis.com/risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/logo.png"));
           assert.equal(element.$.image.src, "test object url");
           done();
         }, 100);

--- a/test/unit/rise-image.html
+++ b/test/unit/rise-image.html
@@ -294,12 +294,11 @@
         } );
 
         suite( "_getFileUrl", () => {
-
-          test( "should return correctly constructed url for GCS JSON API", (done) => {
+          test( "should encode file path", (done) => {
             let filePath = "risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/unit-test-do-not-delete/Ü-+ test%20encoding ([!@?,#$])=1+2-A&%.jpg";
             let fileUrl = element._getFileUrl( filePath );
 
-            assert.equal(fileUrl, "https://storage.googleapis.com/storage/v1/b/risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/o/unit-test-do-not-delete%2FU%CC%88-%2B%20test%2520encoding%20(%5B!%40%3F%2C%23%24%5D)%3D1%2B2-A%26%25.jpg?alt=media");
+            assert.isTrue(fileUrl.indexOf("/risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/") > 0, "forward slash in file path is not encoded" );
 
             fetch(fileUrl)
               .then( (res) => {
@@ -310,8 +309,7 @@
                 assert.fail( error );
                 done();
               } );
-          } );
-
+          });
         } );
 
         suite( "_handleStartForPreview", () => {
@@ -331,7 +329,7 @@
 
             assert.isTrue( element.handleFileStatusUpdated.calledWith({
               filePath: "risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/logo.png",
-              fileUrl: "https://storage.googleapis.com/storage/v1/b/risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/o/logo.png?alt=media",
+              fileUrl: "https://storage.googleapis.com/risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/logo.png",
               status: "current"
             } ));
           } );
@@ -342,19 +340,19 @@
 
             assert.deepEqual( element.__proto__.__proto__.handleFileStatusUpdated.args[0][0], {
               filePath: "risemedialibrary-abc123/test1.png",
-              fileUrl: "https://storage.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/test1.png?alt=media",
+              fileUrl: "https://storage.googleapis.com/risemedialibrary-abc123/test1.png",
               status: "current"
             } );
 
             assert.deepEqual( element.__proto__.__proto__.handleFileStatusUpdated.args[1][0], {
               filePath: "risemedialibrary-abc123/test2.png",
-              fileUrl: "https://storage.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/test2.png?alt=media",
+              fileUrl: "https://storage.googleapis.com/risemedialibrary-abc123/test2.png",
               status: "current"
             } );
 
             assert.deepEqual( element.__proto__.__proto__.handleFileStatusUpdated.args[2][0], {
               filePath: "risemedialibrary-abc123/test3.png",
-              fileUrl: "https://storage.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/test3.png?alt=media",
+              fileUrl: "https://storage.googleapis.com/risemedialibrary-abc123/test3.png",
               status: "current"
             } );
           } );
@@ -369,7 +367,7 @@
 
             assert.isTrue( element.__proto__.__proto__.handleFileStatusUpdated.calledWith({
               filePath: "risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/logo.png",
-              fileUrl: "https://storage.googleapis.com/storage/v1/b/risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/o/logo.png?alt=media",
+              fileUrl: "https://storage.googleapis.com/risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/logo.png",
               status: "current"
             } ));
           } );


### PR DESCRIPTION
## Description
Due to the unreliability of GCS responding with `access-control-allow-origin` header for a 304 response when the request has included `If-None-Match`, we moved forward with doing a HEAD request to obtain `etag` in StoreFilesMixin. Given this, there is no good reason to construct GCS url to JSON API format. Reverting this back the way it was before.

## Motivation and Context
Small incremental steps to caching images in Browser to support running in Shared Schedules. 

## How Has This Been Tested?
Test coverage updated and did a manual test with template presentation in editor preview. 

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
n/a
