### PR TITLE
Filter out files flagged as non existent when running for preview

### DIFF
--- a/src/rise-image.js
+++ b/src/rise-image.js
@@ -377,7 +377,11 @@ class RiseImage extends WatchFilesMixin( ValidFilesMixin( base )) {
       }
     }
 
-    const { validFiles } = super.validateFiles( filesList, VALID_FILE_TYPES );
+    let { validFiles } = super.validateFiles( filesList, VALID_FILE_TYPES );
+
+    if ( RisePlayerConfiguration.isPreview() ) {
+      validFiles = this._filterDeletedFilesForPreview( validFiles );
+    }
 
     if ( !validFiles || !validFiles.length ) {
       this._validFiles = [];
@@ -424,11 +428,19 @@ class RiseImage extends WatchFilesMixin( ValidFilesMixin( base )) {
     return entry && entry.exists ? "current" : "deleted";
   }
 
+  _filterDeletedFilesForPreview( files ) {
+    if ( !files || !Array.isArray( files ) ) {
+      return [];
+    }
+
+    return files.filter( file => this._previewStatusFor( file ) !== "deleted" );
+  }
+
   _handleStartForPreview() {
     this._validFiles.forEach( file => super.handleFileStatusUpdated({
       filePath: file,
       fileUrl: this._getFileUrl( file ),
-      status: this._previewStatusFor( file )
+      status: "current"
     }));
   }
 

--- a/test/unit/rise-image.html
+++ b/test/unit/rise-image.html
@@ -936,6 +936,32 @@
           });
         } );
 
+        suite( "_filterDeletedFilesForPreview", () => {
+          setup( () => {
+            element = fixture( "test-block" );
+          });
+
+          test( "should return empty array if files param is invalid", () => {
+            assert.deepEqual(element._filterDeletedFilesForPreview(), []);
+            assert.deepEqual(element._filterDeletedFilesForPreview("test"), []);
+            assert.deepEqual(element._filterDeletedFilesForPreview(123), []);
+          } );
+
+          test( "should return list of files with deleted files filtered out as per metadata", () => {
+            element.metadata = [ { file: "test1.jpg", exists: true }, { file: "test2.jpg", exists: false }, { file: "test3.jpg", exists: true } ];
+
+            assert.deepEqual(element._filterDeletedFilesForPreview(["test1.jpg", "test2.jpg", "test3.jpg"]), [
+              "test1.jpg", "test3.jpg"
+            ]);
+          } );
+
+          test( "should return correct list of files when no metadata exists", () => {
+            const list = ["test1.jpg", "test2.jpg", "test3.jpg"];
+
+            assert.deepEqual(element._filterDeletedFilesForPreview(list), list);
+          } );
+        } );
+
       });
     </script>
   </body>


### PR DESCRIPTION
## Description
Relying on WatchFilesMixin to call `watchedFileDeletedCallback` is ideal for the flow of the component running on Display as its purpose is to react to realtime file updates via messaging from LocalStorage module. It is not ideal for the flow of the component running on Shared Schedules as the component only requires to manage the files its given at startup. 

These changes now account for scenario where metadata has flagged a file(s) as non existent and immediately filter them from the list of valid files so only files that exist are processed. 

## Motivation and Context
Small incremental steps to support video in Shared Schedules

## How Has This Been Tested?
Tested in Shared Schedules with Charles mapping to local common-template and image component sources. Created scenario by 

- Presentation has image component with several files in list
- Deleted one of the files from Storage
- Went back into presentation, saw the file marked as deleted, published the presentation
- Tested in Shared Schedules, file was never requested. 

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
n/a
