### PR TITLE
Revert removal of "time-created" cachebuster when running in preview

### DIFF
--- a/src/rise-image.js
+++ b/src/rise-image.js
@@ -436,6 +436,16 @@ class RiseImage extends WatchFilesMixin( ValidFilesMixin( base )) {
     return files.filter( file => this._previewStatusFor( file ) !== "deleted" );
   }
 
+  _timeCreatedFor( file ) {
+    if ( !this._hasMetadata()) {
+      return "";
+    }
+
+    const entry = this._metadataEntryFor( file );
+
+    return entry && entry[ "time-created" ] ? entry[ "time-created" ] : "";
+  }
+
   _handleStartForPreview() {
     this._validFiles.forEach( file => super.handleFileStatusUpdated({
       filePath: file,
@@ -457,7 +467,7 @@ class RiseImage extends WatchFilesMixin( ValidFilesMixin( base )) {
   }
 
   _getFileUrl( file ) {
-    return RiseImage.STORAGE_PREFIX + this._encodePath( file );
+    return RiseImage.STORAGE_PREFIX + this._encodePath( file ) + "?_=" + this._timeCreatedFor( file );
   }
 
   _encodePath( filePath ) {

--- a/test/integration/rise-image-logo.html
+++ b/test/integration/rise-image-logo.html
@@ -245,7 +245,7 @@
 
         // delay to account for promise resolve
         setTimeout(() => {
-          assert.isTrue(element.getFile.calledWith("https://storage.googleapis.com/risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/logo.png"));
+          assert.isTrue(element.getFile.calledWith("https://storage.googleapis.com/risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/logo.png?_="));
           assert.equal(element.$.image.src, "test object url");
           done();
         }, 100);

--- a/test/integration/rise-image-multiple.html
+++ b/test/integration/rise-image-multiple.html
@@ -344,7 +344,7 @@
 
         // delay to account for promise resolve
         setTimeout(() => {
-          assert.isTrue(element.getFile.calledWith("https://storage.googleapis.com/risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f/rise-image-demo/canadiens_logo.gif"));
+          assert.isTrue(element.getFile.calledWith("https://storage.googleapis.com/risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f/rise-image-demo/canadiens_logo.gif?_="));
           assert.equal(element.$.image.src, "test object url");
           done();
         }, 100);
@@ -364,9 +364,9 @@
 
         // delay to account for promise resolve
         setTimeout(() => {
-          assert.equal(element.getFile.args[0][0], "https://storage.googleapis.com/risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f/rise-image-demo/canadiens_logo.gif");
-          assert.equal(element.getFile.args[1][0], "https://storage.googleapis.com/risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f/rise-image-demo/blue-jays-logo.jpg");
-          assert.equal(element.getFile.args[2][0], "https://storage.googleapis.com/risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f/rise-image-demo/raptors_logo.png");
+          assert.equal(element.getFile.args[0][0], "https://storage.googleapis.com/risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f/rise-image-demo/canadiens_logo.gif?_=");
+          assert.equal(element.getFile.args[1][0], "https://storage.googleapis.com/risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f/rise-image-demo/blue-jays-logo.jpg?_=");
+          assert.equal(element.getFile.args[2][0], "https://storage.googleapis.com/risemedialibrary-7fa5ee92-7deb-450b-a8d5-e5ed648c575f/rise-image-demo/raptors_logo.png?_=");
           assert.equal(element.$.image.src, "test object url");
 
           element._startTransitionTimer.restore();

--- a/test/integration/rise-image-single.html
+++ b/test/integration/rise-image-single.html
@@ -233,7 +233,7 @@
 
         // delay to account for promise resolve
         setTimeout(() => {
-          assert.isTrue(element.getFile.calledWith("https://storage.googleapis.com/risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/logo.png"));
+          assert.isTrue(element.getFile.calledWith("https://storage.googleapis.com/risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/logo.png?_="));
           assert.equal(element.$.image.src, "test object url");
           done();
         }, 100);

--- a/test/unit/rise-image.html
+++ b/test/unit/rise-image.html
@@ -329,7 +329,7 @@
 
             assert.isTrue( element.handleFileStatusUpdated.calledWith({
               filePath: "risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/logo.png",
-              fileUrl: "https://storage.googleapis.com/risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/logo.png",
+              fileUrl: "https://storage.googleapis.com/risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/logo.png?_=",
               status: "current"
             } ));
           } );
@@ -340,19 +340,19 @@
 
             assert.deepEqual( element.__proto__.__proto__.handleFileStatusUpdated.args[0][0], {
               filePath: "risemedialibrary-abc123/test1.png",
-              fileUrl: "https://storage.googleapis.com/risemedialibrary-abc123/test1.png",
+              fileUrl: "https://storage.googleapis.com/risemedialibrary-abc123/test1.png?_=",
               status: "current"
             } );
 
             assert.deepEqual( element.__proto__.__proto__.handleFileStatusUpdated.args[1][0], {
               filePath: "risemedialibrary-abc123/test2.png",
-              fileUrl: "https://storage.googleapis.com/risemedialibrary-abc123/test2.png",
+              fileUrl: "https://storage.googleapis.com/risemedialibrary-abc123/test2.png?_=",
               status: "current"
             } );
 
             assert.deepEqual( element.__proto__.__proto__.handleFileStatusUpdated.args[2][0], {
               filePath: "risemedialibrary-abc123/test3.png",
-              fileUrl: "https://storage.googleapis.com/risemedialibrary-abc123/test3.png",
+              fileUrl: "https://storage.googleapis.com/risemedialibrary-abc123/test3.png?_=",
               status: "current"
             } );
           } );
@@ -367,7 +367,7 @@
 
             assert.isTrue( element.__proto__.__proto__.handleFileStatusUpdated.calledWith({
               filePath: "risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/logo.png",
-              fileUrl: "https://storage.googleapis.com/risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/logo.png",
+              fileUrl: "https://storage.googleapis.com/risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/logo.png?_=123",
               status: "current"
             } ));
           } );


### PR DESCRIPTION
## Description
In testing our new StoreFilesMixin class for fetching and caching images/videos, it's evident now that the HEAD request for file (to compare cached response etag to new response etag) is in itself being cached by the Browser due to GCS setting a `Cache-Control` header of 24 hours. 

This is a problem in the scenario where a user updated a file and then returns to template editor page of their presentation with Image component and refreshes the page to see their updated image shown. The cached version of file is being shown due to the browser caching the HEAD request. 

Previously we accounted for this scenario by using the `time-created` metadata property to include in the file url to ensure the browser returns latest file. This `time-created` value is set by Image directive in Attribute Editor when the presentation opens as it detects for a new version when it loads the thumbnail of the image and sets `time-created` on the metadata for that file.

Now reverting to use this again so users will immediately see their latest image in the template when refreshing the  template editor page.

**Note**
This `time-created` mechanism is not in place for Video as video is not shown in Template Editor. Also, the `time-created` does not fully resolve this issue on Shared Schedules as there is the scenario where a user updates an image in Storage but does not return to Template Editor presentation in order to re-publish. 

Due to this, we need to modify our StoreFilesMixin to account for HEAD requests being cached by Browser, so a follow up PR in rise-common-component will address this. 

## Motivation and Context
Small incremental steps to caching images in Browser for Shared Schedules (and editor preview).

## How Has This Been Tested?
Presentation in template editor using Charles to map to local component version

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
n/a
