### PR TITLE
Set flag for omitting checking cached file status for Editor Preview

### DIFF
--- a/src/rise-image.js
+++ b/src/rise-image.js
@@ -249,7 +249,14 @@ class RiseImage extends WatchFilesMixin( ValidFilesMixin( base )) {
   }
 
   _renderImageForPreview( fileUrl ) {
-    super.getFile( fileUrl )
+    /*
+      Ensure to set 'omitCheckingCachedStatus' flag to true on getFile() call if running in Editor Preview to avoid unnecessary HEAD requests
+      This is because we append 'time-created' value from metadata in the file url to ensure we get the latest version of file,
+      as well as we check 'exists' in metadata to ensure to filter out a deleted file(s) upon start/reset
+     */
+    const omitCheckingCachedStatus = RisePlayerConfiguration.Helpers.isEditorPreview();
+
+    super.getFile( fileUrl, omitCheckingCachedStatus )
       .then( objectUrl => {
         if ( typeof objectUrl === "string" ) {
           this.$.image.src = objectUrl;
@@ -260,7 +267,6 @@ class RiseImage extends WatchFilesMixin( ValidFilesMixin( base )) {
         // TODO: handle error
         console.error( error );
       })
-    // TODO: revoke the previously stored objectUrl and now store reference to latest objectUrl
   }
 
   _renderImage( filePath, fileUrl ) {

--- a/test/integration/rise-image-logging.html
+++ b/test/integration/rise-image-logging.html
@@ -57,6 +57,10 @@
     let element;
 
     setup(() => {
+        RisePlayerConfiguration.Helpers = {
+            isEditorPreview: () => {return false;}
+        };
+
       RisePlayerConfiguration.LocalStorage = {
         watchSingleFile: ( file, handler ) => {
             handler({ status: "CURRENT", filePath: SAMPLE_PATH, fileUrl: SAMPLE_URL });

--- a/test/integration/rise-image-logo.html
+++ b/test/integration/rise-image-logo.html
@@ -32,6 +32,9 @@
         info: () => {},
         error: () => {},
         warning: () => {}
+      },
+      Helpers: {
+        isEditorPreview: () => {return false;}
       }
     };
 

--- a/test/integration/rise-image-multiple.html
+++ b/test/integration/rise-image-multiple.html
@@ -34,6 +34,9 @@
         info: () => {},
         error: () => {},
         warning: () => {}
+      },
+      Helpers: {
+        isEditorPreview: () => {return false;}
       }
     };
 

--- a/test/integration/rise-image-single.html
+++ b/test/integration/rise-image-single.html
@@ -64,6 +64,10 @@
         RisePlayerConfiguration.LocalMessaging = {
           isConnected: () => { return true; }
         }
+
+        RisePlayerConfiguration.Helpers = {
+          isEditorPreview: () => {return false;}
+        };
       });
 
       teardown(() => {

--- a/test/unit/rise-image.html
+++ b/test/unit/rise-image.html
@@ -53,6 +53,10 @@
             error: () => {}
           };
 
+          RisePlayerConfiguration.Helpers = {
+            isEditorPreview: () => {return false;}
+          };
+
           RisePlayerConfiguration.isPreview = () => false;
 
           element = fixture("test-block");
@@ -280,16 +284,25 @@
           test( "should make getFile() call of StoreFilesMixin with correct file url", () => {
             element._renderImageForPreview("https://storage.googleapis.com/risemedialibrary-abc123/test1.png?_=");
 
-            assert.isTrue(element.getFile.calledWith("https://storage.googleapis.com/risemedialibrary-abc123/test1.png?_="));
+            assert.isTrue(element.getFile.calledWith("https://storage.googleapis.com/risemedialibrary-abc123/test1.png?_=", false));
           } );
 
           test( "should set src of image with object url", (done) => {
             element._renderImageForPreview("https://storage.googleapis.com/risemedialibrary-abc123/test1.png?_=");
 
             setTimeout(() => {
+              assert.isTrue(element.getFile.calledWith("https://storage.googleapis.com/risemedialibrary-abc123/test1.png?_=", false));
               assert.equal(element.$.image.src, "test object url");
               done();
             }, 100);
+          } );
+
+          test( "should set flag to omit checking cached status if running on Editor Preview", () => {
+            sinon.stub(RisePlayerConfiguration.Helpers, "isEditorPreview").returns(true);
+
+            element._renderImageForPreview("https://storage.googleapis.com/risemedialibrary-abc123/test1.png?_=");
+
+            assert.isTrue(element.getFile.calledWith("https://storage.googleapis.com/risemedialibrary-abc123/test1.png?_=", true));
           } );
         } );
 


### PR DESCRIPTION
## Description
Now ensuring to avoid unnecessary HEAD requests when running in Template Editor Preview by setting flag on `getFile()` call of StoreFilesMixin

See PR https://github.com/Rise-Vision/rise-common-component/pull/56 for change in StoreFilesMixin for details

## Motivation and Context
Small incremental steps to cache files in Browser to support Shared Schedules

## How Has This Been Tested?
In Apps template editor via Charles mapping to local version of Image component that was built to use these changes. 

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
n/a
