### PR TITLE
Prevent repetitive flow of configuring showing image for a single image

### DIFF
--- a/src/rise-image.js
+++ b/src/rise-image.js
@@ -325,6 +325,11 @@ class RiseImage extends WatchFilesMixin( ValidFilesMixin( base )) {
       this._renderImage( fileToRender.filePath, fileToRender.fileUrl );
       this._startTransitionTimer();
     } else {
+      if ( this._filesToRenderList.length === 1 ) {
+        // single image, no need to run _configureShowingImages, just run transition timer
+        return this._startTransitionTimer();
+      }
+
       this._configureShowingImages();
     }
   }

--- a/test/unit/rise-image.html
+++ b/test/unit/rise-image.html
@@ -472,6 +472,8 @@
 
             setup( () => {
               sandbox.stub(element.__proto__.__proto__, '_sendDoneEvent');
+              sandbox.spy(element, "_configureShowingImages");
+              sandbox.spy(element, "_startTransitionTimer");
             });
 
             teardown( () => {
@@ -498,6 +500,30 @@
               element._onShowImageComplete();
 
               assert.equal( element._transitionIndex, 1);
+            });
+
+            test("should only start transition timer if managing single image", () => {
+              element.setAttribute( "play-until-done", true);
+
+              element._transitionIndex = 0;
+              element._filesToRenderList = [{ filePath: "risemedialibrary-abc123/test.jpg", fileUrl: "https://storage.googleapis.com/risemedialibrary-abc123/test.jpg"}];
+
+              element._onShowImageComplete();
+
+              assert.isTrue( element._startTransitionTimer.called);
+              assert.isFalse( element._configureShowingImages.called);
+            });
+
+            test("should only call _configureShowingImages when managing multiple images and cycle is complete", () => {
+              element.setAttribute( "play-until-done", true);
+
+              element._transitionIndex = 2;
+              element._filesToRenderList = [{ filePath: "risemedialibrary-abc123/test1.jpg", fileUrl: "https://storage.googleapis.com/risemedialibrary-abc123/test1.jpg"}, { filePath: "risemedialibrary-abc123/test2.jpg", fileUrl: "https://storage.googleapis.com/risemedialibrary-abc123/test2.jpg"}, { filePath: "risemedialibrary-abc123/test3.jpg", fileUrl: "https://storage.googleapis.com/risemedialibrary-abc123/test3.jpg"}];
+
+              element._onShowImageComplete();
+
+              assert.isFalse( element._startTransitionTimer.called);
+              assert.isTrue( element._configureShowingImages.called);
             });
 
           });


### PR DESCRIPTION
## Description
When configured for a single image and transition timer ends, only start the transition timer again instead of unnecessarily running flow of configuring showing images. 

This is to prevent resetting the `src` of image with a new object url when running in editor preview or Shared Schedules which causes a visual flicker upon every transition timer end. 

This visual flicker did not previously occur on Editor Preview or on a Display because the `src` on _iron-image_ instance was being set with the exact same file url again, which `iron-image` correctly does nothing if this is the case. With our new functionality for fetching files when running in editor preview or shared schedules, StoreFilesMixin provides an object url to set the `src` with and it is a different object url every time, hence _iron-image_ proceeds with setting the new src which causes the reload/flicker. 

## Motivation and Context
Small incremental steps to caching images in Browser to support Shared Schedules

## How Has This Been Tested?
In template editor preview and in Shared Schedules using Charles to map to local version of component. 

**Note**
Changes in PR #79 are also required for this to be fully fixed and validated. 

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
n/a
