### PR TITLE
Add env verifier params to applicable file urls

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-image",
-  "version": "1.1.12",
+  "version": "1.1.13",
   "description": "Web component built for Templates to display an image from Storage",
   "repository": "https://github.com/Rise-vision/rise-image.git",
   "bugs": {

--- a/src/rise-image.js
+++ b/src/rise-image.js
@@ -430,7 +430,21 @@ class RiseImage extends WatchFilesMixin( ValidFilesMixin( RiseElement )) {
   }
 
   _getFileUrl( file ) {
-    return RiseImage.STORAGE_PREFIX + this._encodePath( file ) + "?_=" + this._timeCreatedFor( file );
+    let url = RiseImage.STORAGE_PREFIX + this._encodePath( file ) + "?_=" + this._timeCreatedFor( file );
+
+    if (RisePlayerConfiguration.Helpers.getViewerType && RisePlayerConfiguration.Helpers.getViewerType()) {
+      url += "&type=" + RisePlayerConfiguration.Helpers.getViewerType();
+    }
+
+    if (RisePlayerConfiguration.Helpers.getViewerEnv && RisePlayerConfiguration.Helpers.getViewerEnv()) {
+      url += "&env=" + RisePlayerConfiguration.Helpers.getViewerEnv();
+    }
+
+    if (RisePlayerConfiguration.Helpers.getViewerId && RisePlayerConfiguration.Helpers.getViewerId()) {
+      url += "&viewerId=" + RisePlayerConfiguration.Helpers.getViewerId();
+    }
+
+    return url;
   }
 
   _encodePath( filePath ) {

--- a/src/rise-image.js
+++ b/src/rise-image.js
@@ -433,11 +433,11 @@ class RiseImage extends WatchFilesMixin( ValidFilesMixin( RiseElement )) {
     let url = RiseImage.STORAGE_PREFIX + this._encodePath( file ) + "?_=" + this._timeCreatedFor( file );
 
     if (RisePlayerConfiguration.Helpers.getViewerType && RisePlayerConfiguration.Helpers.getViewerType()) {
-      url += "&type=" + RisePlayerConfiguration.Helpers.getViewerType();
+      url += "&viewerType=" + RisePlayerConfiguration.Helpers.getViewerType();
     }
 
     if (RisePlayerConfiguration.Helpers.getViewerEnv && RisePlayerConfiguration.Helpers.getViewerEnv()) {
-      url += "&env=" + RisePlayerConfiguration.Helpers.getViewerEnv();
+      url += "&viewerEnv=" + RisePlayerConfiguration.Helpers.getViewerEnv();
     }
 
     if (RisePlayerConfiguration.Helpers.getViewerId && RisePlayerConfiguration.Helpers.getViewerId()) {

--- a/test/integration/rise-image-logo.html
+++ b/test/integration/rise-image-logo.html
@@ -32,7 +32,8 @@
         info: () => {},
         error: () => {},
         warning: () => {}
-      }
+      },
+      Helpers: {}
     };
 
     RisePlayerConfiguration.LocalMessaging = {

--- a/test/integration/rise-image-multiple.html
+++ b/test/integration/rise-image-multiple.html
@@ -34,7 +34,8 @@
         info: () => {},
         error: () => {},
         warning: () => {}
-      }
+      },
+      Helpers: {}
     };
 
     RisePlayerConfiguration.LocalMessaging = {

--- a/test/integration/rise-image-single.html
+++ b/test/integration/rise-image-single.html
@@ -24,7 +24,8 @@
         info: () => {},
         error: () => {},
         warning: () => {}
-      }
+      },
+      Helpers: {}
     };
   </script>
   <script src="../../src/rise-image.js" type="module"></script>

--- a/test/unit/rise-image.html
+++ b/test/unit/rise-image.html
@@ -282,7 +282,7 @@
             let filePath = "risemedialibrary-123/file.jpg";
             let fileUrl = element._getFileUrl( filePath );
 
-            assert.equal(fileUrl, "https://storage.googleapis.com/risemedialibrary-123/file.jpg?_=&type=test_type");
+            assert.equal(fileUrl, "https://storage.googleapis.com/risemedialibrary-123/file.jpg?_=&viewerType=test_type");
 
             stub.reset();
           } );
@@ -293,7 +293,7 @@
             let filePath = "risemedialibrary-123/file.jpg";
             let fileUrl = element._getFileUrl( filePath );
 
-            assert.equal(fileUrl, "https://storage.googleapis.com/risemedialibrary-123/file.jpg?_=&env=test_env");
+            assert.equal(fileUrl, "https://storage.googleapis.com/risemedialibrary-123/file.jpg?_=&viewerEnv=test_env");
 
             stub.reset();
           } );

--- a/test/unit/rise-image.html
+++ b/test/unit/rise-image.html
@@ -24,6 +24,11 @@
         },
         LocalStorage: {
           watchSingleFile: () => {}
+        },
+        Helpers: {
+          getViewerType: () => {},
+          getViewerEnv: () => {},
+          getViewerId: () => {}
         }
       };
     </script>
@@ -271,6 +276,41 @@
             } );
           } );
 
+          test( "should add 'type' parameter", () => {
+            var stub = sinon.stub( RisePlayerConfiguration.Helpers, "getViewerType" ).returns( "test_type" );
+
+            let filePath = "risemedialibrary-123/file.jpg";
+            let fileUrl = element._getFileUrl( filePath );
+
+            assert.equal(fileUrl, "https://storage.googleapis.com/risemedialibrary-123/file.jpg?_=&type=test_type");
+
+            stub.reset();
+          } );
+
+          test( "should add 'env' parameter", () => {
+            var stub = sinon.stub( RisePlayerConfiguration.Helpers, "getViewerEnv" ).returns( "test_env" );
+
+            let filePath = "risemedialibrary-123/file.jpg";
+            let fileUrl = element._getFileUrl( filePath );
+
+            assert.equal(fileUrl, "https://storage.googleapis.com/risemedialibrary-123/file.jpg?_=&env=test_env");
+
+            stub.reset();
+          } );
+
+          test( "should add 'viewerId' parameter", () => {
+            var stub = sinon.stub( RisePlayerConfiguration.Helpers, "getViewerId" ).returns( "test_viewerId" );
+
+            let filePath = "risemedialibrary-123/file.jpg";
+            let fileUrl = element._getFileUrl( filePath );
+
+            assert.equal(fileUrl, "https://storage.googleapis.com/risemedialibrary-123/file.jpg?_=&viewerId=test_viewerId");
+
+            stub.reset();
+          } );
+
+
+          
         } );
 
         suite( "_handleStartForPreview", () => {


### PR DESCRIPTION
## Description
Add 3 env verifier parameters to the file request URL

## Motivation and Context
Env verifier requirements - analyze data usage based on env verifier parameters.

## How Has This Been Tested?
- Added unit tests
- Used Charles proxy to run it locally, then confirmed in Chrome inspector that env verifier parameters were added to the file URL.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
