### PR TITLE
Use latest rise-common-component v1.10.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-image",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -3029,8 +3029,8 @@
       }
     },
     "rise-common-component": {
-      "version": "git://github.com/Rise-Vision/rise-common-component.git#6e7cdf943ada636fe3936ff377b71537068282c6",
-      "from": "git://github.com/Rise-Vision/rise-common-component.git#v1.10.1",
+      "version": "git://github.com/Rise-Vision/rise-common-component.git#a3d17acc3cdec62b1e5c32f67340d1e13494557a",
+      "from": "git://github.com/Rise-Vision/rise-common-component.git#v1.10.2",
       "requires": {
         "@polymer/polymer": "3.1.0",
         "@polymer/test-fixture": "~4.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-image",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "Web component built for Templates to display an image from Storage",
   "repository": "https://github.com/Rise-vision/rise-image.git",
   "bugs": {
@@ -18,7 +18,7 @@
     "pretty": "eslint . --fix"
   },
   "dependencies": {
-    "rise-common-component": "git://github.com/Rise-Vision/rise-common-component.git#v1.10.1",
+    "rise-common-component": "git://github.com/Rise-Vision/rise-common-component.git#v1.10.2",
     "@polymer/iron-image": "^3.0.1"
   },
   "devDependencies": {},


### PR DESCRIPTION
## Description
Use latest rise-common-component, see https://github.com/Rise-Vision/rise-common-component/pull/78

## Motivation and Context
See PR see https://github.com/Rise-Vision/rise-common-component/pull/78

## How Has This Been Tested?
Using Charles to map to local version of component

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
