### PR TITLE
Don't log error on initial load failure

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-image",
-  "version": "1.3.5",
+  "version": "1.3.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -917,10 +917,38 @@
             "to-regex": "^3.0.1"
           }
         },
+        "fill-range": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+          "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+          "requires": {
+            "extend-shallow": "^2.0.1",
+            "is-number": "^3.0.0",
+            "repeat-string": "^1.6.1",
+            "to-regex-range": "^2.1.0"
+          }
+        },
+        "is-number": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+          "requires": {
+            "kind-of": "^3.0.2"
+          }
+        },
         "isobject": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
           "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+        },
+        "to-regex-range": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
+          "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+          "requires": {
+            "is-number": "^3.0.0",
+            "repeat-string": "^1.6.1"
+          }
         }
       }
     },
@@ -1455,14 +1483,6 @@
       "integrity": "sha512-bCg29ictuBaKUwwArK4ouCaqDgLZcysCFLmM/Yn/FDoqndh/9vNuQfXRDvTuXKLxfD/JtZQGKFT8MGcJBK644g==",
       "requires": {
         "flat-cache": "^2.0.1"
-      }
-    },
-    "fill-range": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
-      "requires": {
-        "to-regex-range": "^5.0.1"
       }
     },
     "find-up": {
@@ -2013,11 +2033,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.1.tgz",
       "integrity": "sha512-2z6JzQvZRa9A2Y7xC6dQQm4FSTSTNWjKIYYTt4246eMTJmIo0Q+ZyOsU66X8lxK1AbB92dFeglPLrhwpeRKO6w=="
-    },
-    "is-number": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
     },
     "is-number-object": {
       "version": "1.0.5",
@@ -3668,14 +3683,6 @@
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
           "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw=="
         }
-      }
-    },
-    "to-regex-range": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
-      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-      "requires": {
-        "is-number": "^7.0.0"
       }
     },
     "tough-cookie": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-image",
-  "version": "1.3.5",
+  "version": "1.3.6",
   "description": "Web component built for Templates to display an image from Storage",
   "repository": "https://github.com/Rise-vision/rise-image.git",
   "bugs": {

--- a/src/rise-image.js
+++ b/src/rise-image.js
@@ -159,12 +159,12 @@ class RiseImage extends WatchFilesMixin( ValidFilesMixin( RiseElement )) {
       if ( this._validFiles.length === 1 ) {
         // clear the image src value to ensure browser executes load of the same image again upon transition timer finishing
         this._clearDisplayedImage();
+      } else {
+        // cancel transition timer and move on to loading next image immediately
+        timeOut.cancel( this._transitionTimer );
+        this._transitionTimer = null;
+        this._onShowImageComplete();
       }
-
-      // cancel transition timer and move on to loading next image immediately
-      timeOut.cancel( this._transitionTimer );
-      this._transitionTimer = null;
-      this._onShowImageComplete();
     });
 
     this.$.image.addEventListener( "loaded-changed", event => {

--- a/src/rise-image.js
+++ b/src/rise-image.js
@@ -99,6 +99,7 @@ class RiseImage extends WatchFilesMixin( ValidFilesMixin( RiseElement )) {
 
     this._validFiles = [];
     this._filesToRenderList = [];
+    this._filesFailedToLoad = [];
     this._initialStart = true;
     this._transitionIndex = 0;
     this._transitionTimer = null;
@@ -124,28 +125,43 @@ class RiseImage extends WatchFilesMixin( ValidFilesMixin( RiseElement )) {
 
   _configureImageEventListeners() {
     this.$.image.addEventListener( "error-changed", ( event ) => {
-      // This value is the 'error' property of <iron-image> and indicates if the last set src failed to load.
-      const failed = event.detail.value;
-
-      if ( !failed ) {
-        // since it didn't fail, don't execute further
-        return;
-      }
-
       // to prevent test coverage failing
       if ( this._filesToRenderList.length === 0 ) {
         return;
       }
 
-      const filePath = this._filesToRenderList[ this._transitionIndex ].filePath,
+      // This value is the 'error' property of <iron-image> and indicates if the last set src failed to load.
+      const failed = event.detail.value,
+        filePath = this._filesToRenderList[ this._transitionIndex ].filePath,
         fileUrl = this._filesToRenderList[ this._transitionIndex ].fileUrl,
         errorCode = fileUrl && fileUrl.startsWith(RiseImage.STORAGE_PREFIX) ? "E000000011" : "E000000200";
 
-      super.log( RiseImage.LOG_TYPE_ERROR, "image-load-fail", {errorCode}, {
-        storage: super.getStorageData( filePath, fileUrl )
-      });
-      this._sendImageEvent( RiseImage.EVENT_IMAGE_ERROR, { filePath, errorMessage: "image load failed" });
+      if ( !failed ) {
+        // if this file previously failed to load then remove it from the failed list
+        if ( this._filesFailedToLoad.indexOf( filePath ) > -1 ) {
+          this._filesFailedToLoad.splice( this._filesFailedToLoad.indexOf( filePath ), 1);
+        }
 
+        // since it didn't fail, don't execute further
+        return;
+      }
+
+      if ( !this._filesFailedToLoad.includes( filePath )) {
+        // initial failure - don't log, instead add to list and allow for potential recovery on next load
+        this._filesFailedToLoad.push( filePath );
+      } else {
+        super.log( RiseImage.LOG_TYPE_ERROR, "image-load-fail", {errorCode}, {
+          storage: super.getStorageData( filePath, fileUrl )
+        });
+        this._sendImageEvent( RiseImage.EVENT_IMAGE_ERROR, { filePath, errorMessage: "image load failed" });
+      }
+
+      if ( this._validFiles.length === 1 ) {
+        // clear the image src value to ensure browser executes load of the same image again upon transition timer finishing
+        this._clearDisplayedImage();
+      }
+
+      // cancel transition timer and move on to loading next image immediately
       timeOut.cancel( this._transitionTimer );
       this._transitionTimer = null;
       this._onShowImageComplete();
@@ -402,6 +418,7 @@ class RiseImage extends WatchFilesMixin( ValidFilesMixin( RiseElement )) {
   _stop() {
     this._validFiles = [];
     this._filesToRenderList = [];
+    this._filesFailedToLoad = [];
 
     super.stopWatch();
     this._clearFirstDownloadTimer();

--- a/test/integration/rise-image-logging.html
+++ b/test/integration/rise-image-logging.html
@@ -310,8 +310,13 @@
         }, 1000 );
     });
 
-    test("should log an 'image-load-fail'", () => {
+    test("should log an 'image-load-fail' upon more than one failure", () => {
         element.dispatchEvent( new CustomEvent( "start" ));
+
+        element.$.image.dispatchEvent( new CustomEvent( "error-changed", { detail: { value: true } } ));
+
+        // shouldn't log upon first failure
+        assert.isFalse(RisePlayerConfiguration.Logger.error.called);
 
         element.$.image.dispatchEvent( new CustomEvent( "error-changed", { detail: { value: true } } ));
 

--- a/test/integration/rise-image-single.html
+++ b/test/integration/rise-image-single.html
@@ -100,7 +100,7 @@
         assert.equal(element.$.image.src, SAMPLE_URL2);
       });
 
-      /*test('it should not update files that were removed', () => {
+      test('it should not update files that were removed', () => {
         element.dispatchEvent( new CustomEvent( "start" ) );
 
         assert.equal(element.$.image.src, SAMPLE_URL);
@@ -151,11 +151,11 @@
           assert.isTrue(element._startEmptyPlayUntilDoneTimer.called);
           done();
         }, 200);
-      });*/
+      });
 
     });
 
-    /*suite('error', () => {
+    suite('error', () => {
       setup(() => {
         RisePlayerConfiguration.LocalStorage = {
           watchSingleFile: (file, handler) => {
@@ -252,7 +252,7 @@
         assert.equal(element.$.image.src, "https://storage.googleapis.com/risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/logo.png?_=");
       });
 
-    });*/
+    });
   });
 
 </script>

--- a/test/integration/rise-image-single.html
+++ b/test/integration/rise-image-single.html
@@ -100,7 +100,7 @@
         assert.equal(element.$.image.src, SAMPLE_URL2);
       });
 
-      test('it should not update files that were removed', () => {
+      /*test('it should not update files that were removed', () => {
         element.dispatchEvent( new CustomEvent( "start" ) );
 
         assert.equal(element.$.image.src, SAMPLE_URL);
@@ -151,11 +151,11 @@
           assert.isTrue(element._startEmptyPlayUntilDoneTimer.called);
           done();
         }, 200);
-      });
+      });*/
 
     });
 
-    suite('error', () => {
+    /*suite('error', () => {
       setup(() => {
         RisePlayerConfiguration.LocalStorage = {
           watchSingleFile: (file, handler) => {
@@ -252,7 +252,7 @@
         assert.equal(element.$.image.src, "https://storage.googleapis.com/risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/logo.png?_=");
       });
 
-    });
+    });*/
   });
 
 </script>

--- a/test/unit/rise-image.html
+++ b/test/unit/rise-image.html
@@ -30,7 +30,8 @@
           getViewerEnv: () => {},
           getViewerId: () => {},
           isEditorPreview: () => {},
-          isInViewer: () => {}
+          isInViewer: () => {},
+          isDisplay: () => { return true; }
         }
       };
     </script>


### PR DESCRIPTION
## Description
On the initial load attempt of a file, if it fails, the component does not log an error. Instead it stores `filePath` in a list to reference in subsequent load failures. 

On subsequent load attempts of a file that previously failed, if it fails again, log an error. 

When component has only one image to show, if the load fails, ensure to clear the `src` value so that browser definitely executes loading the image on subsequent attempts. Previous to this change, the `src` value was not being cleared and so when the url is the same as what is set on `src`, the browser doesn't execute a load. 

## Motivation and Context
Address issue #98 . The latest [investigation and analysis](https://docs.google.com/document/d/1njpQARG4BskJcsCpgS2ob-emNqVlZmYeszCHavpmuoA/edit#bookmark=id.ns1860to53mq) of defect #98 has informed us that in the majority of cases:

- the file is not corrupt
- the file fails only on first load

Given the above, the best improvement is to not log on an initial failure and allow a chance for recovery on subsequent load. 

## How Has This Been Tested?
Tested with [performance standards schedule](https://apps.risevision.com/schedules/details/e8410297-f398-40a3-9e54-7f2a784f5fd1?cid=fee1f642-cdd1-4bc4-8f93-1fc97cb00d55) and mapping to local version of component via Charles proxy

## Release Plan:
- Deploy to production today. 
- Analyze logs over next 2 days.
  - As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
  - As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
no
